### PR TITLE
Fix crash on tool_result with non-array, non-string content

### DIFF
--- a/src/message-store.ts
+++ b/src/message-store.ts
@@ -296,7 +296,10 @@ export class MessageStore {
         if (typeof block.content === 'string') {
           return this.tokenEstimator(block.content);
         }
-        return block.content.reduce((sum, b) => sum + this.estimateBlockTokens(b), 0);
+        if (Array.isArray(block.content)) {
+          return block.content.reduce((sum, b) => sum + this.estimateBlockTokens(b), 0);
+        }
+        return 0;
       case 'image':
         return block.tokenEstimate ?? 1000; // Default estimate for images
       case 'document':


### PR DESCRIPTION
Defensive check in estimateBlockTokens: tool_result content can be undefined (e.g. from JSON.stringify(undefined)), not just string or array. Return 0 tokens for unrecognized content shapes.