### PR TITLE
feat: add isolate, debugLogContext, and maxMessageTokens config options

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -36,6 +36,15 @@ interface ContextManagerBaseConfig {
    * Messages remain shared (no namespace) for Option B multi-agent scenarios.
    */
   namespace?: string;
+  /**
+   * When true, this context manager uses an isolated message store.
+   * Used by ephemeral/subagent context managers that should not share messages.
+   */
+  isolate?: boolean;
+  /**
+   * When true, log the compiled context to stderr for debugging.
+   */
+  debugLogContext?: boolean;
 }
 
 /**

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -71,6 +71,12 @@ export interface ContextStrategy {
   readonly name: string;
 
   /**
+   * Maximum tokens per individual message (used by framework to truncate
+   * large tool results before they enter the context window).
+   */
+  maxMessageTokens?: number;
+
+  /**
    * Initialize the strategy with context.
    * Called when strategy is set on ContextManager.
    */


### PR DESCRIPTION
Support ephemeral/subagent context managers (isolate), debug output (debugLogContext), and per-strategy message token limits (maxMessageTokens) as used by agent-framework's MCPL and stream segmentation features.