### PR TITLE
Rename to @animalabs/context-manager + npm deps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Build & Publish
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+
+      - name: Test
+        run: npm test
+
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@connectome/context-manager",
+  "name": "@animalabs/context-manager",
   "version": "0.1.0",
   "description": "Context management layer for LLM-based agents using Chronicle and Membrane",
   "type": "module",
@@ -21,7 +21,8 @@
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
-    "test": "node --test dist/test/*.test.js"
+    "test": "node --test dist/test/*.test.js",
+    "prepublishOnly": "npm run build"
   },
   "keywords": [
     "connectome",
@@ -34,8 +35,8 @@
   "author": "Anima Research",
   "license": "MIT",
   "dependencies": {
-    "chronicle": "file:../chronicle",
-    "membrane": "file:../membrane"
+    "@animalabs/chronicle": "^0.1.0",
+    "@animalabs/membrane": "^0.5.40"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/blob-manager.ts
+++ b/src/blob-manager.ts
@@ -1,4 +1,4 @@
-import type { JsStore } from 'chronicle';
+import type { JsStore } from '@animalabs/chronicle';
 import type {
   ContentBlock,
   ImageContent,
@@ -6,7 +6,7 @@ import type {
   AudioContent,
   VideoContent,
   Base64Source,
-} from 'membrane';
+} from '@animalabs/membrane';
 import type { BlobReference, StoredContentBlock } from './types/index.js';
 
 /**

--- a/src/context-log.ts
+++ b/src/context-log.ts
@@ -1,5 +1,5 @@
-import type { JsStore } from 'chronicle';
-import type { ContentBlock } from 'membrane';
+import type { JsStore } from '@animalabs/chronicle';
+import type { ContentBlock } from '@animalabs/membrane';
 import type {
   MessageId,
   ContextEntry,

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -1,5 +1,5 @@
-import { JsStore } from 'chronicle';
-import type { Membrane, NormalizedMessage, ContentBlock } from 'membrane';
+import { JsStore } from '@animalabs/chronicle';
+import type { Membrane, NormalizedMessage, ContentBlock } from '@animalabs/membrane';
 import type {
   MessageId,
   Sequence,

--- a/src/message-store.ts
+++ b/src/message-store.ts
@@ -1,5 +1,5 @@
-import type { JsStore } from 'chronicle';
-import type { ContentBlock } from 'membrane';
+import type { JsStore } from '@animalabs/chronicle';
+import type { ContentBlock } from '@animalabs/membrane';
 import type {
   MessageId,
   Sequence,

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1,5 +1,5 @@
-import type { Membrane, NormalizedRequest, ContentBlock, CompleteOptions } from 'membrane';
-import { NativeFormatter } from 'membrane';
+import type { Membrane, NormalizedRequest, ContentBlock, CompleteOptions } from '@animalabs/membrane';
+import { NativeFormatter } from '@animalabs/membrane';
 import type {
   ContextStrategy,
   ResettableStrategy,

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock, NormalizedMessage } from 'membrane';
+import type { ContentBlock, NormalizedMessage } from '@animalabs/membrane';
 import type { MessageId, StoredContentBlock } from './message.js';
 
 /**

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -1,4 +1,4 @@
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 
 /**
  * Unique identifier for a message in the store.

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -1,4 +1,4 @@
-import type { Membrane } from 'membrane';
+import type { Membrane } from '@animalabs/membrane';
 import type { StoredMessage, MessageId, Sequence } from './message.js';
 import type { ContextEntry, TokenBudget, PendingWork } from './context.js';
 

--- a/test/autobiographical.test.ts
+++ b/test/autobiographical.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import { rmSync, existsSync } from 'node:fs';
 import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
-import { Membrane, AnthropicAdapter } from 'membrane';
+import { Membrane, AnthropicAdapter } from '@animalabs/membrane';
 
 const TEST_STORE_PATH = './test-autobio-store';
 const API_KEY = process.env.ANTHROPIC_API_KEY || '';

--- a/test/head-window-reset.test.ts
+++ b/test/head-window-reset.test.ts
@@ -24,7 +24,7 @@ import {
   PassthroughStrategy,
   isResettableStrategy,
 } from '../src/index.js';
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 
 const TEST_STORE_PATH = './test-head-window-reset';
 

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -2,8 +2,8 @@ import { describe, it, before, after, skip } from 'node:test';
 import assert from 'node:assert';
 import { rmSync, existsSync } from 'node:fs';
 import { ContextManager, PassthroughStrategy, AutobiographicalStrategy, ContextLog, MessageStore } from '../src/index.js';
-import { JsStore } from 'chronicle';
-import type { ContentBlock } from 'membrane';
+import { JsStore } from '@animalabs/chronicle';
+import type { ContentBlock } from '@animalabs/membrane';
 import type { ContextStrategy, StrategyContext, ReadinessState, MessageStoreView, ContextLogView, TokenBudget, ContextEntry, StoredMessage, SourceRelation, ContextInjection } from '../src/types/index.js';
 
 const TEST_STORE_PATH = './test-context-store';

--- a/test/knowledge.test.ts
+++ b/test/knowledge.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert';
 import { rmSync, existsSync } from 'node:fs';
 import { ContextManager, KnowledgeStrategy } from '../src/index.js';
-import type { ContentBlock } from 'membrane';
+import type { ContentBlock } from '@animalabs/membrane';
 import type { KnowledgeConfig, SummaryEntry } from '../src/types/index.js';
 
 const TEST_STORE_PATH = './test-knowledge-store';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,11 @@
     "sourceMap": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "composite": true
+    "composite": true,
+    "paths": {
+      "@animalabs/chronicle": ["../chronicle/index.d.ts"],
+      "@animalabs/membrane": ["../membrane/dist/index.d.ts"]
+    }
   },
   "include": ["src/**/*", "test/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- Renames package from `@connectome/context-manager` to `@animalabs/context-manager`
- Updates `chronicle` and `membrane` deps from `file:` refs to `@animalabs/*` npm packages
- Renames all imports across src/ and test/ (~14 files)
- Adds tsconfig `paths` for local development against sibling packages
- Adds `prepublishOnly` script

## Part of
npm publishing initiative — depends on `@animalabs/chronicle` and `@animalabs/membrane` being published first.

## Test plan
- [ ] `npx tsc --noEmit` passes ✅ (verified locally)
- [ ] Existing tests pass after `npm install` with published deps
- [ ] `npm publish --access public` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)