### PR TITLE
feat: head window cache marker for prompt caching

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -413,6 +413,7 @@ export class ContextManager {
     const messages: NormalizedMessage[] = entries.map((entry) => ({
       participant: entry.participant,
       content: entry.content,
+      ...(entry.cacheMarker ? { cacheBreakpoint: true } : {}),
     }));
 
     // If no injections, log and return early

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -245,12 +245,14 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
       if (totalTokens + tokens > maxTokens) break;
 
+      const isLastHeadMsg = i === headEnd - 1 || i === messages.length - 1;
       entries.push({
         index: entries.length,
         sourceMessageId: msg.id,
         sourceRelation: 'copy',
         participant: msg.participant,
         content,
+        cacheMarker: isLastHeadMsg,
       });
       totalTokens += tokens;
     }
@@ -733,12 +735,14 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
       if (totalTokens + tokens > maxTokens) break;
 
+      const isLastHeadMsg = i === headEnd - 1 || i === messages.length - 1;
       entries.push({
         index: entries.length,
         sourceMessageId: msg.id,
         sourceRelation: 'copy',
         participant: msg.participant,
         content,
+        cacheMarker: isLastHeadMsg,
       });
       totalTokens += tokens;
     }

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -245,16 +245,18 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
       if (totalTokens + tokens > maxTokens) break;
 
-      const isLastHeadMsg = i === headEnd - 1 || i === messages.length - 1;
       entries.push({
         index: entries.length,
         sourceMessageId: msg.id,
         sourceRelation: 'copy',
         participant: msg.participant,
         content,
-        cacheMarker: isLastHeadMsg,
       });
       totalTokens += tokens;
+    }
+    // Mark the last head entry as a cache boundary (even if budget truncated the window)
+    if (entries.length > 0) {
+      entries[entries.length - 1].cacheMarker = true;
     }
 
     // 2. Middle zone: compressed chunks as diary pairs, uncompressed as raw messages.
@@ -735,16 +737,18 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
       if (totalTokens + tokens > maxTokens) break;
 
-      const isLastHeadMsg = i === headEnd - 1 || i === messages.length - 1;
       entries.push({
         index: entries.length,
         sourceMessageId: msg.id,
         sourceRelation: 'copy',
         participant: msg.participant,
         content,
-        cacheMarker: isLastHeadMsg,
       });
       totalTokens += tokens;
+    }
+    // Mark the last head entry as a cache boundary (even if budget truncated the window)
+    if (entries.length > 0) {
+      entries[entries.length - 1].cacheMarker = true;
     }
 
     // Compute recent window exclusion set (also exclude head window messages)

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1616,6 +1616,44 @@ describe('ContextManager', () => {
       }
     });
   });
+  describe('Cache Marker Placement', () => {
+    it('should place cacheBreakpoint on the last head window message', async () => {
+      cleanup();
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy: new AutobiographicalStrategy({ headWindowTokens: 4000, recentWindowTokens: 30000 }),
+      });
+
+      // Add enough messages to have a head window
+      manager.addMessage('user', [{ type: 'text', text: 'First message in the conversation' }]);
+      manager.addMessage('assistant', [{ type: 'text', text: 'Reply to first message' }]);
+      manager.addMessage('user', [{ type: 'text', text: 'Second user message' }]);
+      manager.addMessage('assistant', [{ type: 'text', text: 'Reply to second message' }]);
+
+      const { messages } = await manager.compile();
+
+      // At least one message should have cacheBreakpoint
+      const markedMessages = messages.filter(m => m.cacheBreakpoint);
+      assert.ok(markedMessages.length > 0, 'At least one message should have cacheBreakpoint');
+
+      // Exactly one cache breakpoint should be placed (at the head window boundary)
+      assert.strictEqual(markedMessages.length, 1, 'Exactly one cacheBreakpoint should be placed');
+    });
+
+    it('should place cacheBreakpoint even when all messages fit in head window', async () => {
+      cleanup();
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy: new AutobiographicalStrategy({ headWindowTokens: 100000, recentWindowTokens: 30000 }),
+      });
+
+      manager.addMessage('user', [{ type: 'text', text: 'Only message' }]);
+
+      const { messages } = await manager.compile();
+      const marked = messages.filter(m => m.cacheBreakpoint);
+      assert.strictEqual(marked.length, 1, 'Should have cacheBreakpoint even with single message');
+    });
+  });
 });
 
 // Run with: node --test dist/test/integration.test.js


### PR DESCRIPTION
## Summary

- **Cache marker placement**: AutobiographicalStrategy marks the last head window entry with `cacheMarker: true` in both legacy and hierarchical select paths
- **Compile forwarding**: `ContextManager.compile()` maps `ContextEntry.cacheMarker` to `NormalizedMessage.cacheBreakpoint`, enabling Membrane's `cache_control` placement
- **Budget truncation fix**: marker is placed post-loop on the last emitted entry, so it survives budget exhaustion mid-head-window

Depends on: antra-tess/membrane#12 (for `cache_control` to actually be applied in native tool mode)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] 46/46 integration tests pass (44 existing + 2 new cache marker tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)