### PR TITLE
feat(strategy): persistent and branch-aware strategy state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@animalabs/context-manager",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@animalabs/context-manager",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@animalabs/chronicle": "^0.1.0",
@@ -32,21 +32,6 @@
         "@animalabs/chronicle-linux-x64-gnu": "0.1.1",
         "@animalabs/chronicle-win32-x64-msvc": "0.1.1"
       }
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-linux-x64-gnu": {
-      "optional": true
-    },
-    "node_modules/@animalabs/chronicle/node_modules/@animalabs/chronicle-win32-x64-msvc": {
-      "optional": true
     },
     "node_modules/@animalabs/membrane": {
       "version": "0.5.41",

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -437,11 +437,15 @@ export class ContextManager {
     budget?: TokenBudget,
     injections?: ContextInjection[]
   ): Promise<CompileResult> {
-    // Check readiness and wait if needed
-    const readiness = this.strategy.checkReadiness();
-    if (!readiness.ready && readiness.pendingWork) {
-      await readiness.pendingWork;
-    }
+    // Don't block the agent's turn on speculative compression — let it
+    // run in the background. The strategy renders whatever's available
+    // now; the next compile picks up the freshly-formed L1.
+    //
+    // Old behavior (await pendingWork to fold the latest chunk before
+    // the agent responds) added 30+ seconds of latency per turn whenever
+    // a chunk was forming, which is unacceptable UX for an agent that
+    // streams its responses. We accept "this turn doesn't have the very
+    // latest L1" in exchange for non-blocking compile.
 
     // Default budget
     const effectiveBudget: TokenBudget = budget ?? {
@@ -637,6 +641,29 @@ export class ContextManager {
   getSummary(id: string): SummaryEntry | null {
     if (!isSearchableStrategy(this.strategy)) return null;
     return this.strategy.getSummary(id);
+  }
+
+  /**
+   * Per-render stats from the active strategy: head/tail message + token
+   * counts, plus per-level summary counts and total tokens. Returns null
+   * if the strategy doesn't implement `getRenderStats`.
+   *
+   * Designed for TUIs / dashboards that want to display "how much of the
+   * agent's context is folded vs raw" at a glance.
+   */
+  getRenderStats(): {
+    head: { messages: number; tokens: number };
+    tail: { messages: number; tokens: number };
+    summaries: {
+      l1: { count: number; tokens: number };
+      l2: { count: number; tokens: number };
+      l3: { count: number; tokens: number };
+    };
+    pending: { chunks: number; merges: number };
+  } | null {
+    const fn = (this.strategy as { getRenderStats?: (s: unknown) => unknown }).getRenderStats;
+    if (typeof fn !== 'function') return null;
+    return fn.call(this.strategy, this.messageStore.createView()) as ReturnType<NonNullable<typeof this.getRenderStats>>;
   }
 
   /**

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -16,8 +16,11 @@ import type {
   ContextInjection,
   CompileResult,
   ProtectedRange,
+  SearchQuery,
+  SearchResult,
+  SummaryEntry,
 } from './types/index.js';
-import { isResettableStrategy, isPinnableStrategy } from './types/index.js';
+import { isResettableStrategy, isPinnableStrategy, isSearchableStrategy } from './types/index.js';
 import { MessageStore, MessageStoreEvent } from './message-store.js';
 import { ContextLog } from './context-log.js';
 import { PassthroughStrategy } from './strategies/passthrough.js';
@@ -612,6 +615,28 @@ export class ContextManager {
   listPins(): ReadonlyArray<ProtectedRange> {
     if (!isPinnableStrategy(this.strategy)) return [];
     return this.strategy.listPins();
+  }
+
+  // ==========================================================================
+  // Search (passthrough to the active strategy)
+  // ==========================================================================
+
+  /**
+   * Search the strategy's summary archive (substring or regex over content).
+   * Returns empty array if the strategy doesn't support search.
+   *
+   * Suitable for building memory-search agent tools at the framework layer
+   * — see e.g. agent-framework's MCPL host integration.
+   */
+  searchSummaries(query: SearchQuery): SearchResult[] {
+    if (!isSearchableStrategy(this.strategy)) return [];
+    return this.strategy.searchSummaries(query);
+  }
+
+  /** Look up a single summary by id. Returns null if not found / unsupported. */
+  getSummary(id: string): SummaryEntry | null {
+    if (!isSearchableStrategy(this.strategy)) return null;
+    return this.strategy.getSummary(id);
   }
 
   /**

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -15,8 +15,9 @@ import type {
   MessageQueryResult,
   ContextInjection,
   CompileResult,
+  ProtectedRange,
 } from './types/index.js';
-import { isResettableStrategy } from './types/index.js';
+import { isResettableStrategy, isPinnableStrategy } from './types/index.js';
 import { MessageStore, MessageStoreEvent } from './message-store.js';
 import { ContextLog } from './context-log.js';
 import { PassthroughStrategy } from './strategies/passthrough.js';
@@ -568,6 +569,49 @@ export class ContextManager {
    */
   getStrategy(): ContextStrategy {
     return this.strategy;
+  }
+
+  // ==========================================================================
+  // Pins / documents (passthrough to the active strategy)
+  // ==========================================================================
+
+  /**
+   * Pin a range of messages so they aren't compressed and render raw at
+   * their original chronological position. Returns the new pin id.
+   *
+   * Throws if the active strategy doesn't support pins.
+   */
+  pinRange(firstMessageId: MessageId, lastMessageId: MessageId, opts?: { name?: string }): string {
+    if (!isPinnableStrategy(this.strategy)) {
+      throw new Error('Active strategy does not support pins');
+    }
+    return this.strategy.pinRange(firstMessageId, lastMessageId, opts);
+  }
+
+  /**
+   * Mark a single message as a "document" (semantically a body of
+   * information to retain in full). Same effect as a single-message pin
+   * with `kind: 'document'`. Returns the new pin id.
+   */
+  markDocument(messageId: MessageId, opts?: { name?: string }): string {
+    if (!isPinnableStrategy(this.strategy)) {
+      throw new Error('Active strategy does not support documents');
+    }
+    return this.strategy.markDocument(messageId, opts);
+  }
+
+  /** Remove a pin or document mark. Returns true if removed. */
+  unpin(pinId: string): boolean {
+    if (!isPinnableStrategy(this.strategy)) {
+      throw new Error('Active strategy does not support pins');
+    }
+    return this.strategy.unpin(pinId);
+  }
+
+  /** List all current pins. Returns empty array if strategy is not pinnable. */
+  listPins(): ReadonlyArray<ProtectedRange> {
+    if (!isPinnableStrategy(this.strategy)) return [];
+    return this.strategy.listPins();
   }
 
   /**

--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -93,6 +93,8 @@ export class ContextManager {
   /** Whether we own the store (created it) vs app owns it (passed in) */
   private ownsStore: boolean;
   private debugLogContext: boolean;
+  /** Namespace passed to strategies for scoping their persistent state slots. */
+  private strategyNamespace: string;
 
   private constructor(
     store: JsStore,
@@ -100,6 +102,7 @@ export class ContextManager {
     contextLog: ContextLog,
     strategy: ContextStrategy,
     ownsStore: boolean,
+    strategyNamespace: string,
     membrane?: Membrane,
     debugLogContext = false,
   ) {
@@ -108,6 +111,7 @@ export class ContextManager {
     this.contextLog = contextLog;
     this.strategy = strategy;
     this.ownsStore = ownsStore;
+    this.strategyNamespace = strategyNamespace;
     this.membrane = membrane;
     this.debugLogContext = debugLogContext;
 
@@ -173,12 +177,18 @@ export class ContextManager {
     });
     const strategy = config.strategy ?? new PassthroughStrategy();
 
+    // Namespace passed to strategies. Falls back to a stable per-store value
+    // so strategies always have something to scope state IDs by, even when
+    // the caller didn't supply a namespace.
+    const strategyNamespace = config.namespace ?? 'default';
+
     const manager = new ContextManager(
       store,
       messageStore,
       contextLog,
       strategy,
       ownsStore,
+      strategyNamespace,
       config.membrane,
       config.debugLogContext ?? false,
     );
@@ -294,6 +304,10 @@ export class ContextManager {
   /**
    * Create a branch from a specific message.
    * The new branch will have state as of that message's sequence (time-travel branching).
+   *
+   * Returns the new branch *name*, which is what `switchBranch` and `forkAt`
+   * expect. (Chronicle's branch APIs are name-keyed; the numeric `id` field
+   * on JsBranch is an internal identifier and isn't accepted by switchBranch.)
    */
   branchAt(messageId: MessageId, name?: string): string {
     const message = this.messageStore.get(messageId);
@@ -303,21 +317,50 @@ export class ContextManager {
 
     // Create branch name if not provided
     const branchName = name ?? `branch-${Date.now()}`;
-    
+
     // Get current branch name to branch from
     const currentBranch = this.store.currentBranch();
-    
+
     // Use createBranchAt to branch at the message's sequence (time-travel)
     const branch = this.store.createBranchAt(branchName, currentBranch.name, message.sequence);
 
-    return branch.id;
+    return branch.name;
   }
 
   /**
    * Switch to a different branch.
+   *
+   * Re-initializes the strategy after switching so any branch-scoped state
+   * stored on Chronicle is reloaded. Strategies that hold derived in-memory
+   * caches (e.g. AutobiographicalStrategy.summaries) need this to avoid
+   * showing the previous branch's state on the new branch.
    */
-  switchBranch(branchId: string): void {
+  async switchBranch(branchId: string): Promise<void> {
     this.store.switchBranch(branchId);
+    await this.initializeStrategy();
+  }
+
+  /**
+   * Fork from the current head: create a new branch at the current sequence
+   * and switch to it. The new branch starts with all current state (messages,
+   * context log, and strategy state) and diverges from there.
+   *
+   * Use this when an agent wants to explore an alternate timeline from
+   * "now" — e.g. trying a different response without committing.
+   *
+   * For time-travel branching at a specific historical message, use
+   * `branchAt(messageId, name?)` instead, then `switchBranch(name)`.
+   *
+   * Returns the new branch's name. The strategy is re-initialized on the
+   * new branch so it picks up the forked state.
+   */
+  async fork(name?: string): Promise<string> {
+    const branchName = name ?? `fork-${Date.now()}`;
+    const currentBranch = this.store.currentBranch();
+    const currentSeq = this.store.currentSequence();
+    const branch = this.store.createBranchAt(branchName, currentBranch.name, currentSeq);
+    await this.switchBranch(branch.name);
+    return branch.name;
   }
 
   /**
@@ -583,6 +626,8 @@ export class ContextManager {
       contextLog: this.contextLog.createView(),
       membrane: this.membrane,
       currentSequence: this.store.currentSequence(),
+      store: this.store,
+      namespace: this.strategyNamespace,
     };
   }
 

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -983,35 +983,75 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     selectedSummaries.push(...l1Selected);
     totalSummaryTokens += l1Used;
 
-    // Emit summaries as a single Q&A pair
+    // Emit summaries as Q/A recall pairs.
+    // Default (positionedRecallPairs=true): one Q/A pair per summary, sorted
+    // chronologically by source-range position. This is the spec-faithful
+    // shape — each memory appears in its temporal place rather than as a
+    // wall of unrelated recollections from another speaker.
+    // Legacy (positionedRecallPairs=false): all summaries concatenated into
+    // a single Q/A pair between head and tail.
     if (selectedSummaries.length > 0) {
-      const contextLabel = this.config.summaryContextLabel ?? 'What do you remember from earlier?';
-      const combinedText = selectedSummaries.map(s => s.content).join('\n\n---\n\n');
+      if (this.config.positionedRecallPairs !== false) {
+        const sorted = this.sortSummariesChronologically(selectedSummaries, messages);
+        const summaryParticipant = this.config.summaryParticipant ?? 'Claude';
 
-      const questionEntry: ContextEntry = {
-        index: entries.length,
-        participant: 'Context Manager',
-        content: [{ type: 'text', text: contextLabel }],
-        sourceRelation: 'derived',
-      };
-      // Synthesised summary turns must respect maxMessageTokens. With L1+L2+L3
-      // budgets defaulting to 30k each, an unconstrained concatenation can push
-      // a single assistant turn past 90k tokens, eating the inference budget
-      // and starving recent messages (postmortem 2026-05-04, bug B).
-      const answerContent: ContentBlock[] = [{ type: 'text', text: combinedText }];
-      const answerEntry: ContextEntry = {
-        index: entries.length + 1,
-        participant: this.config.summaryParticipant ?? 'Claude',
-        content: msgCap > 0 ? this.truncateContent(answerContent, msgCap) : answerContent,
-        sourceRelation: 'derived',
-      };
+        for (const summary of sorted) {
+          const headerText = this.buildRecallHeader(summary);
+          const questionEntry: ContextEntry = {
+            index: entries.length,
+            participant: 'Context Manager',
+            content: [{ type: 'text', text: headerText }],
+            sourceRelation: 'derived',
+          };
+          const answerContent: ContentBlock[] = [{ type: 'text', text: summary.content }];
+          const answerEntry: ContextEntry = {
+            index: entries.length + 1,
+            participant: summaryParticipant,
+            content: msgCap > 0 ? this.truncateContent(answerContent, msgCap) : answerContent,
+            sourceRelation: 'derived',
+          };
 
-      const pairTokens = this.estimateTokens(questionEntry.content) +
-                         this.estimateTokens(answerEntry.content);
+          const pairTokens =
+            this.estimateTokens(questionEntry.content) +
+            this.estimateTokens(answerEntry.content);
 
-      entries.push(questionEntry);
-      entries.push(answerEntry);
-      totalTokens += pairTokens;
+          // Stop emitting recall pairs if we'd blow the overall budget.
+          if (totalTokens + pairTokens > maxTokens) break;
+
+          entries.push(questionEntry);
+          entries.push(answerEntry);
+          totalTokens += pairTokens;
+        }
+      } else {
+        // Legacy combined-pair mode
+        const contextLabel = this.config.summaryContextLabel ?? 'What do you remember from earlier?';
+        const combinedText = selectedSummaries.map(s => s.content).join('\n\n---\n\n');
+
+        const questionEntry: ContextEntry = {
+          index: entries.length,
+          participant: 'Context Manager',
+          content: [{ type: 'text', text: contextLabel }],
+          sourceRelation: 'derived',
+        };
+        // Synthesised summary turns must respect maxMessageTokens. With L1+L2+L3
+        // budgets defaulting to 30k each, an unconstrained concatenation can push
+        // a single assistant turn past 90k tokens, eating the inference budget
+        // and starving recent messages (postmortem 2026-05-04, bug B).
+        const answerContent: ContentBlock[] = [{ type: 'text', text: combinedText }];
+        const answerEntry: ContextEntry = {
+          index: entries.length + 1,
+          participant: this.config.summaryParticipant ?? 'Claude',
+          content: msgCap > 0 ? this.truncateContent(answerContent, msgCap) : answerContent,
+          sourceRelation: 'derived',
+        };
+
+        const pairTokens = this.estimateTokens(questionEntry.content) +
+                           this.estimateTokens(answerEntry.content);
+
+        entries.push(questionEntry);
+        entries.push(answerEntry);
+        totalTokens += pairTokens;
+      }
     }
 
     // Phase 4: Recent uncompressed messages (skip head window overlap).
@@ -1067,6 +1107,41 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       used += s.tokens;
     }
     return { selected, tokensUsed: used };
+  }
+
+  /**
+   * Sort selected summaries by source-range start position, so per-pair
+   * recall emission appears in chronological order. Falls back to the
+   * created timestamp for summaries whose source-range first message is
+   * no longer in the store.
+   */
+  protected sortSummariesChronologically(
+    summaries: SummaryEntry[],
+    messages: StoredMessage[],
+  ): SummaryEntry[] {
+    const positionOf = new Map<string, number>();
+    for (let i = 0; i < messages.length; i++) {
+      positionOf.set(messages[i].id, i);
+    }
+    return [...summaries].sort((a, b) => {
+      const posA = positionOf.get(a.sourceRange.first) ?? Number.MAX_SAFE_INTEGER;
+      const posB = positionOf.get(b.sourceRange.first) ?? Number.MAX_SAFE_INTEGER;
+      if (posA !== posB) return posA - posB;
+      return a.created - b.created;
+    });
+  }
+
+  /**
+   * Render the per-pair recall header from the configured template.
+   * Substitutions: {id} {level} {first} {last}.
+   */
+  protected buildRecallHeader(summary: SummaryEntry): string {
+    const template = this.config.recallHeaderTemplate ?? '[Recall {id}]';
+    return template
+      .replace(/\{id\}/g, summary.id)
+      .replace(/\{level\}/g, String(summary.level))
+      .replace(/\{first\}/g, summary.sourceRange.first)
+      .replace(/\{last\}/g, summary.sourceRange.last);
   }
 
   // ============================================================================

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -15,6 +15,8 @@ import type {
   SummaryLevel,
   SummaryEntry,
   ProtectedRange,
+  SearchQuery,
+  SearchResult,
 } from '../types/index.js';
 import { DEFAULT_AUTOBIOGRAPHICAL_CONFIG } from '../types/index.js';
 
@@ -268,6 +270,77 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   /** Read-only list of all current pins. */
   listPins(): ReadonlyArray<ProtectedRange> {
     return this.pins;
+  }
+
+  // ============================================================================
+  // Search (gap #7)
+  // ============================================================================
+
+  /**
+   * Look up a single summary by id. Returns null if not found.
+   */
+  getSummary(id: string): SummaryEntry | null {
+    return this.summaries.find(s => s.id === id) ?? null;
+  }
+
+  /**
+   * Search summaries by substring or regex over their content.
+   *
+   * Result ordering: matches by descending hit count, then by descending
+   * `created` timestamp (newest first within the same hit count).
+   *
+   * Default behavior: only "live" (unmerged) summaries are searched. Set
+   * `includeMerged: true` to also include summaries that have been folded
+   * into a higher level.
+   */
+  searchSummaries(query: SearchQuery): SearchResult[] {
+    const limit = query.limit ?? 50;
+    const includeMerged = query.includeMerged ?? false;
+
+    // Build the matcher
+    let matcher: ((content: string) => number) | null = null;
+    if (query.regex) {
+      const flags = query.regex.flags.includes('g') ? query.regex.flags : query.regex.flags + 'g';
+      const re = new RegExp(query.regex.source, flags);
+      matcher = (content: string) => {
+        const matches = content.match(re);
+        return matches ? matches.length : 0;
+      };
+    } else if (query.text) {
+      const needle = query.text.toLowerCase();
+      matcher = (content: string) => {
+        const hay = content.toLowerCase();
+        let count = 0;
+        let idx = 0;
+        while ((idx = hay.indexOf(needle, idx)) !== -1) {
+          count++;
+          idx += needle.length || 1;
+        }
+        return count;
+      };
+    } else {
+      // No pattern: every summary "matches" once
+      matcher = () => 1;
+    }
+
+    const levelsFilter = query.levels && query.levels.length > 0 ? new Set(query.levels) : null;
+
+    const results: SearchResult[] = [];
+    for (const s of this.summaries) {
+      if (!includeMerged && s.mergedInto) continue;
+      if (levelsFilter && !levelsFilter.has(s.level)) continue;
+      const matches = matcher(s.content);
+      if (matches > 0) {
+        results.push({ summary: s, matches });
+      }
+    }
+
+    results.sort((a, b) => {
+      if (b.matches !== a.matches) return b.matches - a.matches;
+      return b.summary.created - a.summary.created;
+    });
+
+    return results.slice(0, limit);
   }
 
   /**

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -456,22 +456,52 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   async onNewMessage(message: StoredMessage, ctx: StrategyContext): Promise<void> {
     this.rebuildChunks(ctx.messageStore);
 
-    // Auto-tick: fire compression in the background so it runs without
-    // the framework explicitly calling tick(). compile() will await
-    // pendingCompression via checkReadiness().
-    if (this.config.autoTickOnNewMessage && this.compressionQueue.length > 0 && !this.pendingCompression) {
-      // Speculation cap: defer if we already have more pending+pending-merge
-      // L1s than the configured ceiling. Chunks still queue; the next
-      // explicit tick() or compile() will drain them.
-      if (this.isAtSpeculativeCap()) return;
-
-      // Preflight hook (subclass override for predictive scheduling).
-      if (!this.shouldCompressPreflight()) return;
-
-      this.tick(ctx).catch((err) =>
-        console.error('AutobiographicalStrategy: auto-tick error:', err)
-      );
+    // Auto-tick: fire speculative compression in the background. After
+    // each tick completes, if the queue still has work AND we're under
+    // the speculation cap AND preflight allows, schedule another tick.
+    // This drains the queue ahead of need rather than one-chunk-per-
+    // user-turn (reactive). Combined with ContextManager.compile not
+    // awaiting pendingCompression, the agent's response and background
+    // compression run truly in parallel.
+    if (this.config.autoTickOnNewMessage && !this.pendingCompression) {
+      this.driveSpeculativeDrain(ctx);
     }
+  }
+
+  /**
+   * Background-drain loop: keeps calling tick() while there's queued work,
+   * subject to the speculation cap and preflight hook. Recurses via
+   * `queueMicrotask` so one chunk's compression doesn't block the
+   * scheduling of the next.
+   *
+   * Stops if a tick fails to make progress (queue size unchanged) — guards
+   * against runaway recursion when tick is a no-op (e.g. no membrane
+   * configured, or a subclass override that doesn't process the queue).
+   */
+  protected driveSpeculativeDrain(ctx: StrategyContext): void {
+    if (this.pendingCompression) return;
+    if (this.compressionQueue.length === 0 && this.mergeQueue.length === 0) return;
+    if (this.isAtSpeculativeCap()) return;
+    if (!this.shouldCompressPreflight()) return;
+
+    const beforeChunks = this.compressionQueue.length;
+    const beforeMerges = this.mergeQueue.length;
+
+    this.tick(ctx)
+      .then(() => {
+        const afterChunks = this.compressionQueue.length;
+        const afterMerges = this.mergeQueue.length;
+        // Made progress if either queue shrank.
+        const progressed = afterChunks < beforeChunks || afterMerges < beforeMerges;
+        if (!progressed) return;
+        // Recurse to drain more. queueMicrotask defers until the current
+        // task is done, letting other code (the agent's stream consumer)
+        // interleave.
+        queueMicrotask(() => this.driveSpeculativeDrain(ctx));
+      })
+      .catch((err) => {
+        console.error('AutobiographicalStrategy: speculative-drain error:', err);
+      });
   }
 
   /**
@@ -580,6 +610,56 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     };
   }
 
+  /**
+   * Richer per-render stats: requires a message store view to compute the
+   * head + tail (recent window) sizes. Returns counts AND token sums per
+   * summary level, so observers can see "how much of the agent's context
+   * is in raw tail vs folded into L1/L2/L3."
+   *
+   * Useful for TUI / dashboards. The token sums use the strategy's own
+   * token estimates (which match what `select()` uses for budget math).
+   */
+  getRenderStats(store: MessageStoreView): {
+    head: { messages: number; tokens: number };
+    tail: { messages: number; tokens: number };
+    summaries: {
+      l1: { count: number; tokens: number };
+      l2: { count: number; tokens: number };
+      l3: { count: number; tokens: number };
+    };
+    pending: { chunks: number; merges: number };
+  } {
+    const messages = store.getAll();
+    const headStart = this.getHeadWindowStartIndex(store);
+    const headEnd = this.getHeadWindowEnd(store);
+    const recentStart = this.getRecentWindowStart(store);
+
+    const sumTokens = (slice: StoredMessage[]): number =>
+      slice.reduce((acc, m) => acc + store.estimateTokens(m), 0);
+
+    const headMsgs = messages.slice(headStart, headEnd);
+    const tailMsgs = messages.slice(recentStart);
+
+    const live = (level: SummaryLevel) =>
+      this.summaries.filter(s => s.level === level && !s.mergedInto);
+    const sumLevelTokens = (level: SummaryLevel): number =>
+      live(level).reduce((acc, s) => acc + s.tokens, 0);
+
+    return {
+      head: { messages: headMsgs.length, tokens: sumTokens(headMsgs) },
+      tail: { messages: tailMsgs.length, tokens: sumTokens(tailMsgs) },
+      summaries: {
+        l1: { count: live(1).length, tokens: sumLevelTokens(1) },
+        l2: { count: live(2).length, tokens: sumLevelTokens(2) },
+        l3: { count: live(3).length, tokens: sumLevelTokens(3) },
+      },
+      pending: {
+        chunks: this.chunks.filter(c => !c.compressed).length,
+        merges: this.mergeQueue.length,
+      },
+    };
+  }
+
   // ============================================================================
   // Legacy (single-level) path
   // ============================================================================
@@ -602,7 +682,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const msg = messages[i];
       const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
       const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
-      if (totalTokens + tokens > maxTokens) break;
+      if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
 
       entries.push({
         index: entries.length,
@@ -650,7 +730,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         const pairTokens = this.estimateTokens(questionEntry.content) +
                            this.estimateTokens(answerEntry.content);
 
-        if (totalTokens + pairTokens > maxTokens) break;
+        if (this.isOverBudget(totalTokens + pairTokens, maxTokens)) break;
 
         entries.push(questionEntry);
         entries.push(answerEntry);
@@ -660,7 +740,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         for (const msg of chunk.messages) {
           const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
           const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
-          if (totalTokens + tokens > maxTokens) break;
+          if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
 
           entries.push({
             index: entries.length,
@@ -683,7 +763,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const msg = messages[i];
       const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
       const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
-      if (totalTokens + tokens > maxTokens) break;
+      if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
 
       entries.push({
         index: entries.length,
@@ -733,7 +813,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const tokens = msgCap > 0
         ? Math.min(store.estimateTokens(msg), msgCap + 50)
         : store.estimateTokens(msg);
-      if (totalTokensBefore + acceptedTokens + tokens > maxTokens) break;
+      if (this.isOverBudget(totalTokensBefore + acceptedTokens + tokens, maxTokens)) break;
       accepted.push(i);
       acceptedTokens += tokens;
     }
@@ -1169,7 +1249,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const msg = messages[i];
       const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
       const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
-      if (totalTokens + tokens > maxTokens) break;
+      if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
 
       entries.push({
         index: entries.length,
@@ -1206,7 +1286,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     let l3Used = 0;
     for (const s of shownL3) {
       if (l3Used + s.tokens > l3Budget) break;
-      if (totalTokens + totalSummaryTokens + s.tokens > maxTokens) break;
+      if (this.isOverBudget(totalTokens + totalSummaryTokens + s.tokens, maxTokens)) break;
       selectedSummaries.push(s);
       l3Used += s.tokens;
       totalSummaryTokens += s.tokens;
@@ -1218,7 +1298,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const l2Effective = l2Budget + l3Carryover;
     for (const s of shownL2) {
       if (l2Used + s.tokens > l2Effective) break;
-      if (totalTokens + totalSummaryTokens + s.tokens > maxTokens) break;
+      if (this.isOverBudget(totalTokens + totalSummaryTokens + s.tokens, maxTokens)) break;
       selectedSummaries.push(s);
       l2Used += s.tokens;
       totalSummaryTokens += s.tokens;
@@ -1297,7 +1377,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
             const pairTokens =
               this.estimateTokens(questionEntry.content) +
               this.estimateTokens(answerEntry.content);
-            if (totalTokens + pairTokens > maxTokens) break;
+            if (this.isOverBudget(totalTokens + pairTokens, maxTokens)) break;
             entries.push(questionEntry);
             entries.push(answerEntry);
             totalTokens += pairTokens;
@@ -1307,7 +1387,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
             const tokens = msgCap > 0
               ? Math.min(store.estimateTokens(msg), msgCap + 50)
               : store.estimateTokens(msg);
-            if (totalTokens + tokens > maxTokens) break;
+            if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
             entries.push({
               index: entries.length,
               sourceMessageId: msg.id,
@@ -1356,7 +1436,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
           const tokens = msgCap > 0
             ? Math.min(store.estimateTokens(msg), msgCap + 50)
             : store.estimateTokens(msg);
-          if (totalTokens + tokens > maxTokens) break;
+          if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
           entries.push({
             index: entries.length,
             sourceMessageId: msg.id,
@@ -1418,11 +1498,23 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     let used = 0;
     for (const s of shownL1) {
       if (used + s.tokens > budget) break;
-      if (used + s.tokens > maxTokens) break;
+      if (this.isOverBudget(used + s.tokens, maxTokens)) break;
       selected.push(s);
       used += s.tokens;
     }
     return { selected, tokensUsed: used };
+  }
+
+  /**
+   * True if `projectedTotal` exceeds `max` AND the strategy is configured
+   * to enforce budget. When `enforceBudget: false`, always returns false
+   * — the rendering pipeline emits the full ideal context regardless of
+   * budget overage. Caller's API will reject if it exceeds the model's
+   * context window; the philosophy is "surface overage, don't hide it."
+   */
+  protected isOverBudget(projectedTotal: number, max: number): boolean {
+    if (this.config.enforceBudget === false) return false;
+    return projectedTotal > max;
   }
 
   /**

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1,3 +1,4 @@
+import type { JsStore } from '@animalabs/chronicle';
 import type { Membrane, NormalizedRequest, ContentBlock, CompleteOptions } from '@animalabs/membrane';
 import { NativeFormatter } from '@animalabs/membrane';
 import type {
@@ -86,6 +87,14 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   /** Cached result of getHeadWindowStartIndex to avoid repeated linear scans. */
   private _cachedHeadStartIndex: { id: string | null; msgCount: number; result: number } | null = null;
 
+  /** Chronicle store for persistent state. Set in `initialize()`. */
+  protected store: JsStore | null = null;
+  /** Namespace for state-id scoping. Set in `initialize()`. */
+  protected ns: string = '';
+  protected get summariesStateId(): string { return `${this.ns}/autobio:summaries`; }
+  protected get counterStateId(): string { return `${this.ns}/autobio:counter`; }
+  protected get mergeQueueStateId(): string { return `${this.ns}/autobio:mergeQueue`; }
+
   constructor(config: Partial<AutobiographicalConfig> = {}) {
     this.config = { ...DEFAULT_AUTOBIOGRAPHICAL_CONFIG, ...config };
     // Hierarchical is on by default; set hierarchical: false to use legacy single-level
@@ -100,8 +109,15 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   }
 
   async initialize(ctx: StrategyContext): Promise<void> {
+    // Bind to the chronicle store + namespace for persistent strategy state.
+    this.store = ctx.store;
+    this.ns = ctx.namespace;
+    this.registerStates();
+    this.loadPersistedState();
+
     // Restore headWindowStartId from last topic transition message
     const messages = ctx.messageStore.getAll();
+    this.headWindowStartId = null;
     for (let i = messages.length - 1; i >= 0; i--) {
       if (this.isTopicTransitionMessage(messages[i])) {
         this.headWindowStartId = messages[i].id;
@@ -109,6 +125,110 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       }
     }
     this.rebuildChunks(ctx.messageStore);
+  }
+
+  /**
+   * Register the three Chronicle state slots this strategy uses.
+   * Idempotent — chronicle throws if a state is already registered, which we
+   * swallow (the existing slot is what we want).
+   */
+  protected registerStates(): void {
+    if (!this.store) return;
+    try {
+      this.store.registerState({
+        id: this.summariesStateId,
+        strategy: 'append_log',
+        deltaSnapshotEvery: 50,
+        fullSnapshotEvery: 10,
+      });
+    } catch { /* already registered */ }
+    try {
+      this.store.registerState({
+        id: this.counterStateId,
+        strategy: 'snapshot',
+      });
+    } catch { /* already registered */ }
+    try {
+      this.store.registerState({
+        id: this.mergeQueueStateId,
+        strategy: 'snapshot',
+      });
+    } catch { /* already registered */ }
+  }
+
+  /**
+   * Load summaries, counter, and pending merges from chronicle into the
+   * in-memory mirrors. Called on every (re)initialize so branch switches
+   * pick up the new branch's state.
+   */
+  protected loadPersistedState(): void {
+    if (!this.store) {
+      this.summaries = [];
+      this.summaryIdCounter = 0;
+      this.mergeQueue = [];
+      return;
+    }
+    const summaries = this.store.getStateJson(this.summariesStateId);
+    this.summaries = Array.isArray(summaries) ? (summaries as SummaryEntry[]) : [];
+
+    const counter = this.store.getStateJson(this.counterStateId);
+    this.summaryIdCounter = typeof counter === 'number' ? counter : 0;
+
+    const queue = this.store.getStateJson(this.mergeQueueStateId);
+    this.mergeQueue = Array.isArray(queue)
+      ? (queue as Array<{ level: SummaryLevel; sourceIds: string[] }>)
+      : [];
+  }
+
+  /**
+   * Append a summary to the in-memory list and to the chronicle AppendLog.
+   * Single point so subclasses inherit persistence.
+   */
+  protected pushSummary(entry: SummaryEntry): void {
+    this.summaries.push(entry);
+    this.store?.appendToStateJson(this.summariesStateId, entry);
+  }
+
+  /**
+   * Mark a summary as merged into a higher-level summary, updating the
+   * chronicle copy at the same index. Index is the position in `this.summaries`.
+   */
+  protected setMergedInto(entry: SummaryEntry, mergedIntoId: string): void {
+    entry.mergedInto = mergedIntoId;
+    if (!this.store) return;
+    const index = this.summaries.indexOf(entry);
+    if (index < 0) return;
+    this.store.editStateItem(
+      this.summariesStateId,
+      index,
+      Buffer.from(JSON.stringify(entry)),
+    );
+  }
+
+  /**
+   * Allocate the next summary-id counter value and persist the new counter.
+   */
+  protected nextSummaryIdCounter(): number {
+    const value = this.summaryIdCounter++;
+    this.store?.setStateJson(this.counterStateId, this.summaryIdCounter);
+    return value;
+  }
+
+  /**
+   * Push to the merge queue and persist the new queue snapshot.
+   */
+  protected enqueueMerge(merge: { level: SummaryLevel; sourceIds: string[] }): void {
+    this.mergeQueue.push(merge);
+    this.store?.setStateJson(this.mergeQueueStateId, this.mergeQueue);
+  }
+
+  /**
+   * Pop from the merge queue and persist the new queue snapshot.
+   */
+  protected dequeueMerge(): { level: SummaryLevel; sourceIds: string[] } | undefined {
+    const merge = this.mergeQueue.shift();
+    this.store?.setStateJson(this.mergeQueueStateId, this.mergeQueue);
+    return merge;
   }
 
   checkReadiness(): ReadinessState {
@@ -180,7 +300,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
     // Priority 2: Execute pending merges (hierarchical only)
     if (this.config.hierarchical && this.mergeQueue.length > 0) {
-      const merge = this.mergeQueue.shift()!;
+      const merge = this.dequeueMerge()!;
       this.pendingCompression = this.executeMerge(merge.level, merge.sourceIds, ctx);
 
       try {
@@ -595,7 +715,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
       const messageIds = chunk.messages.map(m => m.id);
       const entry: SummaryEntry = {
-        id: `L1-${this.summaryIdCounter++}`,
+        id: `L1-${this.nextSummaryIdCounter()}`,
         level: 1,
         content: summaryText,
         tokens: Math.ceil(summaryText.length / 4),
@@ -609,7 +729,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         phaseType: chunk.phaseType,
       };
 
-      this.summaries.push(entry);
+      this.pushSummary(entry);
       chunk.compressed = true;
       chunk.summaryId = entry.id;
       this._compressionCount++;
@@ -632,7 +752,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const unmergedL1 = this.summaries.filter(s => s.level === 1 && !s.mergedInto);
     if (unmergedL1.length >= threshold) {
       const toMerge = unmergedL1.slice(0, threshold);
-      this.mergeQueue.push({
+      this.enqueueMerge({
         level: 2,
         sourceIds: toMerge.map(s => s.id),
       });
@@ -642,7 +762,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const unmergedL2 = this.summaries.filter(s => s.level === 2 && !s.mergedInto);
     if (unmergedL2.length >= threshold) {
       const toMerge = unmergedL2.slice(0, threshold);
-      this.mergeQueue.push({
+      this.enqueueMerge({
         level: 3,
         sourceIds: toMerge.map(s => s.id),
       });
@@ -735,7 +855,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
       const sourceLevel = (targetLevel - 1) as 0 | 1 | 2;
       const newEntry: SummaryEntry = {
-        id: `L${targetLevel}-${this.summaryIdCounter++}`,
+        id: `L${targetLevel}-${this.nextSummaryIdCounter()}`,
         level: targetLevel,
         content: mergedText,
         tokens: Math.ceil(mergedText.length / 4),
@@ -745,11 +865,15 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         created: Date.now(),
       };
 
-      this.summaries.push(newEntry);
+      // Append the new merged entry first, then mark sources. Persist each
+      // mergedInto edit individually so chronicle reflects the same shape as
+      // the in-memory mirror. (If the process crashes mid-loop, restart sees
+      // the new entry plus a partial set of marked sources; un-marked sources
+      // would re-trigger a merge — accept the rare duplicate over data loss.)
+      this.pushSummary(newEntry);
 
-      // Mark sources as merged
       for (const source of sources) {
-        source.mergedInto = newEntry.id;
+        this.setMergedInto(source, newEntry.id);
       }
 
       // Check if this merge triggers a further merge

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -598,6 +598,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     this.emitRecentNewestFirst(entries, store, messages, recentStart, msgCap, maxTokens, totalTokens);
 
     this.trimOrphanedToolUse(entries);
+    this.pruneToolEntries(entries);
     return entries;
   }
 
@@ -1248,6 +1249,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     this.emitRecentNewestFirst(entries, store, messages, effectiveRecentStart, msgCap, maxTokens, totalTokens);
 
     this.trimOrphanedToolUse(entries);
+    this.pruneToolEntries(entries);
     return entries;
   }
 
@@ -1661,6 +1663,91 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         entries.pop();
       } else {
         break;
+      }
+    }
+  }
+
+  /**
+   * Prune tool_use / tool_result blocks in-place:
+   *  1. Truncate `tool_use.input` blocks whose serialized JSON exceeds
+   *     `toolUseInputMaxTokens`.
+   *  2. For each tool name, keep only the last N `tool_result` blocks
+   *     per `toolResultMaxLastN`; older ones get their `content` replaced
+   *     with a brief marker referencing the tool name and how many newer
+   *     results exist below.
+   *
+   * Both passes are no-ops when the corresponding config is unset/0.
+   * Pruning runs AFTER selection and orphan-trimming, so it doesn't
+   * affect chunk formation or the recall/pin layout.
+   */
+  protected pruneToolEntries(entries: ContextEntry[]): void {
+    // Pass 1: build toolUseId → toolName map and apply input truncation
+    const toolUseInputCap = this.config.toolUseInputMaxTokens ?? 0;
+    const toolUseIdToName = new Map<string, string>();
+
+    for (const entry of entries) {
+      for (let i = 0; i < entry.content.length; i++) {
+        const block = entry.content[i];
+        if (block.type !== 'tool_use') continue;
+        toolUseIdToName.set(block.id, block.name);
+
+        if (toolUseInputCap > 0) {
+          const inputJson = JSON.stringify(block.input);
+          const inputTokens = Math.ceil(inputJson.length / 4);
+          if (inputTokens > toolUseInputCap) {
+            const keys = Object.keys(block.input).slice(0, 5);
+            entry.content[i] = {
+              ...block,
+              input: {
+                _truncated: true,
+                _originalTokens: inputTokens,
+                _keys: keys,
+              },
+            };
+          }
+        }
+      }
+    }
+
+    // Pass 2: collect tool_result occurrences per tool name, in order
+    const occurrencesByTool = new Map<string, Array<{ entry: ContextEntry; blockIndex: number }>>();
+    for (const entry of entries) {
+      for (let i = 0; i < entry.content.length; i++) {
+        const block = entry.content[i];
+        if (block.type !== 'tool_result') continue;
+        const toolName = toolUseIdToName.get(block.toolUseId);
+        if (!toolName) continue;
+        let arr = occurrencesByTool.get(toolName);
+        if (!arr) {
+          arr = [];
+          occurrencesByTool.set(toolName, arr);
+        }
+        arr.push({ entry, blockIndex: i });
+      }
+    }
+
+    // Pass 3: apply per-tool max-last-N
+    const cfg = this.config.toolResultMaxLastN;
+    if (cfg === undefined) return;
+
+    for (const [toolName, occs] of occurrencesByTool) {
+      let limit: number | undefined;
+      if (typeof cfg === 'number') limit = cfg;
+      else if (typeof cfg === 'object') limit = cfg[toolName];
+      if (limit === undefined || limit < 0) continue;
+
+      const excessCount = occs.length - limit;
+      if (excessCount <= 0) continue;
+
+      for (let i = 0; i < excessCount; i++) {
+        const { entry, blockIndex } = occs[i];
+        const orig = entry.content[blockIndex];
+        if (orig.type !== 'tool_result') continue;
+        const fresherCount = occs.length - i - 1;
+        entry.content[blockIndex] = {
+          ...orig,
+          content: `[Result truncated — tool '${toolName}' has ${fresherCount} more recent result${fresherCount === 1 ? '' : 's'} below]`,
+        };
       }
     }
   }

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -387,10 +387,39 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     // the framework explicitly calling tick(). compile() will await
     // pendingCompression via checkReadiness().
     if (this.config.autoTickOnNewMessage && this.compressionQueue.length > 0 && !this.pendingCompression) {
+      // Speculation cap: defer if we already have more pending+pending-merge
+      // L1s than the configured ceiling. Chunks still queue; the next
+      // explicit tick() or compile() will drain them.
+      if (this.isAtSpeculativeCap()) return;
+
+      // Preflight hook (subclass override for predictive scheduling).
+      if (!this.shouldCompressPreflight()) return;
+
       this.tick(ctx).catch((err) =>
         console.error('AutobiographicalStrategy: auto-tick error:', err)
       );
     }
+  }
+
+  /**
+   * Whether the strategy's pending+queued L1 budget has reached the cap
+   * configured by `maxSpeculativeL1s`. If no cap is set, always false.
+   */
+  protected isAtSpeculativeCap(): boolean {
+    const cap = this.config.maxSpeculativeL1s;
+    if (cap === undefined || cap < 0) return false;
+    const unmergedL1s = this.summaries.filter(s => s.level === 1 && !s.mergedInto).length;
+    return unmergedL1s + this.compressionQueue.length > cap;
+  }
+
+  /**
+   * Preflight hook for whether speculative compression should fire on
+   * `onNewMessage`. Returns true by default (current eager behavior).
+   * Subclasses can override for predictive scheduling — e.g. only fire
+   * when the live tail token count is approaching some threshold.
+   */
+  protected shouldCompressPreflight(): boolean {
+    return true;
   }
 
   async tick(ctx: StrategyContext): Promise<void> {

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -789,7 +789,6 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       config: {
         model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
         maxTokens: 2000,
-        temperature: 0,
       },
     };
 
@@ -942,7 +941,6 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       config: {
         model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
         maxTokens: Math.round(targetTokens * 1.5),
-        temperature: 0,
       },
     };
 
@@ -1076,7 +1074,6 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       config: {
         model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
         maxTokens: Math.round(targetTokens * 1.5),
-        temperature: 0,
       },
     };
 
@@ -1500,7 +1497,6 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       config: {
         model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
         maxTokens: 1500,
-        temperature: 0,
       },
     };
 

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -982,12 +982,28 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   /**
    * Check if unmerged summary counts exceed the merge threshold.
    * Enqueues merge operations if so.
+   *
+   * Skips L1s/L2s that are already in a pending merge — without this guard,
+   * each new summary above threshold re-enqueues a merge for the same
+   * already-eligible siblings, producing N near-identical higher-level
+   * summaries when the queue eventually drains.
    */
   protected checkMergeThreshold(): void {
     const threshold = this.config.mergeThreshold ?? 6;
 
+    // IDs that are already part of a queued merge — exclude them from
+    // eligibility so we don't re-enqueue.
+    const queuedL1 = new Set<string>();
+    const queuedL2 = new Set<string>();
+    for (const m of this.mergeQueue) {
+      const set = m.level === 2 ? queuedL1 : queuedL2;
+      for (const id of m.sourceIds) set.add(id);
+    }
+
     // Check L1 → L2
-    const unmergedL1 = this.summaries.filter(s => s.level === 1 && !s.mergedInto);
+    const unmergedL1 = this.summaries.filter(
+      s => s.level === 1 && !s.mergedInto && !queuedL1.has(s.id),
+    );
     if (unmergedL1.length >= threshold) {
       const toMerge = unmergedL1.slice(0, threshold);
       this.enqueueMerge({
@@ -997,7 +1013,9 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     }
 
     // Check L2 → L3
-    const unmergedL2 = this.summaries.filter(s => s.level === 2 && !s.mergedInto);
+    const unmergedL2 = this.summaries.filter(
+      s => s.level === 2 && !s.mergedInto && !queuedL2.has(s.id),
+    );
     if (unmergedL2.length >= threshold) {
       const toMerge = unmergedL2.slice(0, threshold);
       this.enqueueMerge({
@@ -1026,6 +1044,17 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
     if (sources.length !== sourceIds.length) {
       console.warn('executeMerge: some source summaries not found, skipping');
+      return;
+    }
+
+    // Defensive: if every source is already mergedInto something, this is a
+    // stale queue entry (could happen if multiple merges for the same
+    // sourceIds were enqueued before the dedup fix in checkMergeThreshold).
+    // Skip rather than produce a redundant near-identical higher-level entry.
+    if (sources.every(s => s.mergedInto)) {
+      console.warn(
+        `executeMerge: all sources already merged into ${sources[0].mergedInto}, skipping (stale queue entry)`,
+      );
       return;
     }
 

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -14,6 +14,7 @@ import type {
   AutobiographicalConfig,
   SummaryLevel,
   SummaryEntry,
+  ProtectedRange,
 } from '../types/index.js';
 import { DEFAULT_AUTOBIOGRAPHICAL_CONFIG } from '../types/index.js';
 
@@ -94,6 +95,12 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   protected get summariesStateId(): string { return `${this.ns}/autobio:summaries`; }
   protected get counterStateId(): string { return `${this.ns}/autobio:counter`; }
   protected get mergeQueueStateId(): string { return `${this.ns}/autobio:mergeQueue`; }
+  protected get pinsStateId(): string { return `${this.ns}/autobio:pins`; }
+
+  /** Protected ranges (pins + documents). Loaded from chronicle in initialize. */
+  protected pins: ProtectedRange[] = [];
+  /** Monotonically increasing counter for pin ids. Persisted as part of the pins snapshot. */
+  protected pinIdCounter = 0;
 
   constructor(config: Partial<AutobiographicalConfig> = {}) {
     this.config = { ...DEFAULT_AUTOBIOGRAPHICAL_CONFIG, ...config };
@@ -154,6 +161,12 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         strategy: 'snapshot',
       });
     } catch { /* already registered */ }
+    try {
+      this.store.registerState({
+        id: this.pinsStateId,
+        strategy: 'snapshot',
+      });
+    } catch { /* already registered */ }
   }
 
   /**
@@ -166,6 +179,8 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       this.summaries = [];
       this.summaryIdCounter = 0;
       this.mergeQueue = [];
+      this.pins = [];
+      this.pinIdCounter = 0;
       return;
     }
     const summaries = this.store.getStateJson(this.summariesStateId);
@@ -178,6 +193,113 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     this.mergeQueue = Array.isArray(queue)
       ? (queue as Array<{ level: SummaryLevel; sourceIds: string[] }>)
       : [];
+
+    const pinsState = this.store.getStateJson(this.pinsStateId);
+    if (pinsState && typeof pinsState === 'object' && Array.isArray((pinsState as { pins?: unknown }).pins)) {
+      const ps = pinsState as { pins: ProtectedRange[]; counter?: number };
+      this.pins = ps.pins;
+      this.pinIdCounter = typeof ps.counter === 'number' ? ps.counter : ps.pins.length;
+    } else {
+      this.pins = [];
+      this.pinIdCounter = 0;
+    }
+  }
+
+  /** Persist the current pins + counter as a single snapshot. */
+  protected persistPins(): void {
+    this.store?.setStateJson(this.pinsStateId, {
+      pins: this.pins,
+      counter: this.pinIdCounter,
+    });
+  }
+
+  // ============================================================================
+  // Pins / documents (protected ranges)
+  // ============================================================================
+
+  /**
+   * Pin a range of messages so they aren't compressed and render raw at
+   * their original position. Returns the pin id.
+   */
+  pinRange(firstMessageId: string, lastMessageId: string, opts?: { name?: string }): string {
+    const id = `pin-${this.pinIdCounter++}`;
+    this.pins.push({
+      id,
+      firstMessageId,
+      lastMessageId,
+      kind: 'pin',
+      name: opts?.name,
+      created: Date.now(),
+    });
+    this.persistPins();
+    return id;
+  }
+
+  /**
+   * Mark a single message as a "document" — semantically a body of
+   * information the agent wants to retain in full. Functionally a
+   * single-message pin with `kind: 'document'`.
+   */
+  markDocument(messageId: string, opts?: { name?: string }): string {
+    const id = `pin-${this.pinIdCounter++}`;
+    this.pins.push({
+      id,
+      firstMessageId: messageId,
+      lastMessageId: messageId,
+      kind: 'document',
+      name: opts?.name,
+      created: Date.now(),
+    });
+    this.persistPins();
+    return id;
+  }
+
+  /** Remove a pin or document mark by id. Returns true if removed. */
+  unpin(pinId: string): boolean {
+    const before = this.pins.length;
+    this.pins = this.pins.filter(p => p.id !== pinId);
+    if (this.pins.length < before) {
+      this.persistPins();
+      return true;
+    }
+    return false;
+  }
+
+  /** Read-only list of all current pins. */
+  listPins(): ReadonlyArray<ProtectedRange> {
+    return this.pins;
+  }
+
+  /**
+   * Whether a given message position is inside any protected range.
+   * Uses a position map (computed by caller) so callers can avoid
+   * repeated per-message lookups in tight loops.
+   */
+  protected isPositionPinned(position: number, pinPositions: Set<number>): boolean {
+    return pinPositions.has(position);
+  }
+
+  /**
+   * Build a set of message-store positions covered by any pin. O(N pins · K range).
+   * Returns positions for which the message exists; orphan pins (deleted
+   * messages) are silently skipped.
+   */
+  protected pinnedPositions(messages: StoredMessage[]): Set<number> {
+    if (this.pins.length === 0) return new Set();
+    const positionOf = new Map<string, number>();
+    for (let i = 0; i < messages.length; i++) {
+      positionOf.set(messages[i].id, i);
+    }
+    const out = new Set<number>();
+    for (const pin of this.pins) {
+      const first = positionOf.get(pin.firstMessageId);
+      const last = positionOf.get(pin.lastMessageId);
+      if (first === undefined || last === undefined) continue;
+      const lo = Math.min(first, last);
+      const hi = Math.max(first, last);
+      for (let i = lo; i <= hi; i++) out.add(i);
+    }
+    return out;
   }
 
   /**
@@ -983,27 +1105,108 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     selectedSummaries.push(...l1Selected);
     totalSummaryTokens += l1Used;
 
-    // Emit summaries as Q/A recall pairs.
-    // Default (positionedRecallPairs=true): one Q/A pair per summary, sorted
-    // chronologically by source-range position. This is the spec-faithful
-    // shape — each memory appears in its temporal place rather than as a
-    // wall of unrelated recollections from another speaker.
-    // Legacy (positionedRecallPairs=false): all summaries concatenated into
-    // a single Q/A pair between head and tail.
-    if (selectedSummaries.length > 0) {
-      if (this.config.positionedRecallPairs !== false) {
-        const sorted = this.sortSummariesChronologically(selectedSummaries, messages);
-        const summaryParticipant = this.config.summaryParticipant ?? 'Claude';
+    // Emit summaries + pinned messages between head and recent windows.
+    //
+    // Default (positionedRecallPairs=true): one Q/A pair per summary,
+    // interleaved with raw pinned messages, all sorted chronologically by
+    // source-range / message position. Each memory appears in its temporal
+    // place rather than as a wall of unrelated recollections.
+    //
+    // Legacy (positionedRecallPairs=false): summaries concatenated into one
+    // Q/A pair between head and tail; pinned messages still emit raw, in
+    // their chronological positions, after the combined recall pair.
+    const positionOf = new Map<string, number>();
+    for (let i = 0; i < messages.length; i++) {
+      positionOf.set(messages[i].id, i);
+    }
+    const pinnedPositionsSet = this.pinnedPositions(messages);
+    // Pinned messages between head and recent (head/recent pinned ones
+    // already emit raw via Phase 0 / Phase 4).
+    const pinnedInMiddle: { msg: StoredMessage; position: number }[] = [];
+    for (let i = headEnd; i < recentStart; i++) {
+      if (pinnedPositionsSet.has(i)) {
+        pinnedInMiddle.push({ msg: messages[i], position: i });
+      }
+    }
 
-        for (const summary of sorted) {
-          const headerText = this.buildRecallHeader(summary);
+    if (selectedSummaries.length > 0 || pinnedInMiddle.length > 0) {
+      const summaryParticipant = this.config.summaryParticipant ?? 'Claude';
+
+      if (this.config.positionedRecallPairs !== false) {
+        // Build a unified, chronologically-sorted item list.
+        type Item =
+          | { kind: 'summary'; position: number; summary: SummaryEntry }
+          | { kind: 'pin'; position: number; msg: StoredMessage };
+
+        const items: Item[] = [];
+        for (const s of selectedSummaries) {
+          const pos = positionOf.get(s.sourceRange.first) ?? Number.MAX_SAFE_INTEGER;
+          items.push({ kind: 'summary', position: pos, summary: s });
+        }
+        for (const p of pinnedInMiddle) {
+          items.push({ kind: 'pin', position: p.position, msg: p.msg });
+        }
+        items.sort((a, b) => a.position - b.position);
+
+        for (const item of items) {
+          if (item.kind === 'summary') {
+            const summary = item.summary;
+            const headerText = this.buildRecallHeader(summary);
+            const questionEntry: ContextEntry = {
+              index: entries.length,
+              participant: 'Context Manager',
+              content: [{ type: 'text', text: headerText }],
+              sourceRelation: 'derived',
+            };
+            const answerContent: ContentBlock[] = [{ type: 'text', text: summary.content }];
+            const answerEntry: ContextEntry = {
+              index: entries.length + 1,
+              participant: summaryParticipant,
+              content: msgCap > 0 ? this.truncateContent(answerContent, msgCap) : answerContent,
+              sourceRelation: 'derived',
+            };
+            const pairTokens =
+              this.estimateTokens(questionEntry.content) +
+              this.estimateTokens(answerEntry.content);
+            if (totalTokens + pairTokens > maxTokens) break;
+            entries.push(questionEntry);
+            entries.push(answerEntry);
+            totalTokens += pairTokens;
+          } else {
+            const msg = item.msg;
+            const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
+            const tokens = msgCap > 0
+              ? Math.min(store.estimateTokens(msg), msgCap + 50)
+              : store.estimateTokens(msg);
+            if (totalTokens + tokens > maxTokens) break;
+            entries.push({
+              index: entries.length,
+              sourceMessageId: msg.id,
+              sourceRelation: 'copy',
+              participant: msg.participant,
+              content,
+            });
+            totalTokens += tokens;
+          }
+        }
+      } else {
+        // Legacy combined-pair mode for summaries; pins still emit raw at
+        // their positions after the combined pair.
+        if (selectedSummaries.length > 0) {
+          const contextLabel = this.config.summaryContextLabel ?? 'What do you remember from earlier?';
+          const combinedText = selectedSummaries.map(s => s.content).join('\n\n---\n\n');
+
           const questionEntry: ContextEntry = {
             index: entries.length,
             participant: 'Context Manager',
-            content: [{ type: 'text', text: headerText }],
+            content: [{ type: 'text', text: contextLabel }],
             sourceRelation: 'derived',
           };
-          const answerContent: ContentBlock[] = [{ type: 'text', text: summary.content }];
+          // Synthesised summary turns must respect maxMessageTokens. With L1+L2+L3
+          // budgets defaulting to 30k each, an unconstrained concatenation can push
+          // a single assistant turn past 90k tokens, eating the inference budget
+          // and starving recent messages (postmortem 2026-05-04, bug B).
+          const answerContent: ContentBlock[] = [{ type: 'text', text: combinedText }];
           const answerEntry: ContextEntry = {
             index: entries.length + 1,
             participant: summaryParticipant,
@@ -1011,46 +1214,29 @@ export class AutobiographicalStrategy implements ResettableStrategy {
             sourceRelation: 'derived',
           };
 
-          const pairTokens =
-            this.estimateTokens(questionEntry.content) +
-            this.estimateTokens(answerEntry.content);
-
-          // Stop emitting recall pairs if we'd blow the overall budget.
-          if (totalTokens + pairTokens > maxTokens) break;
+          const pairTokens = this.estimateTokens(questionEntry.content) +
+                             this.estimateTokens(answerEntry.content);
 
           entries.push(questionEntry);
           entries.push(answerEntry);
           totalTokens += pairTokens;
         }
-      } else {
-        // Legacy combined-pair mode
-        const contextLabel = this.config.summaryContextLabel ?? 'What do you remember from earlier?';
-        const combinedText = selectedSummaries.map(s => s.content).join('\n\n---\n\n');
 
-        const questionEntry: ContextEntry = {
-          index: entries.length,
-          participant: 'Context Manager',
-          content: [{ type: 'text', text: contextLabel }],
-          sourceRelation: 'derived',
-        };
-        // Synthesised summary turns must respect maxMessageTokens. With L1+L2+L3
-        // budgets defaulting to 30k each, an unconstrained concatenation can push
-        // a single assistant turn past 90k tokens, eating the inference budget
-        // and starving recent messages (postmortem 2026-05-04, bug B).
-        const answerContent: ContentBlock[] = [{ type: 'text', text: combinedText }];
-        const answerEntry: ContextEntry = {
-          index: entries.length + 1,
-          participant: this.config.summaryParticipant ?? 'Claude',
-          content: msgCap > 0 ? this.truncateContent(answerContent, msgCap) : answerContent,
-          sourceRelation: 'derived',
-        };
-
-        const pairTokens = this.estimateTokens(questionEntry.content) +
-                           this.estimateTokens(answerEntry.content);
-
-        entries.push(questionEntry);
-        entries.push(answerEntry);
-        totalTokens += pairTokens;
+        for (const { msg } of pinnedInMiddle) {
+          const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
+          const tokens = msgCap > 0
+            ? Math.min(store.estimateTokens(msg), msgCap + 50)
+            : store.estimateTokens(msg);
+          if (totalTokens + tokens > maxTokens) break;
+          entries.push({
+            index: entries.length,
+            sourceMessageId: msg.id,
+            sourceRelation: 'copy',
+            participant: msg.participant,
+            content,
+          });
+          totalTokens += tokens;
+        }
       }
     }
 
@@ -1246,16 +1432,24 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   // ============================================================================
 
   /**
-   * Get messages in the compressible zone: outside both head window and recent window.
-   * Returns messages from [0, headStart) ∪ [headEnd, recentStart).
+   * Get messages in the compressible zone: outside both head window and
+   * recent window AND not inside any pinned range. Returns messages from
+   * [0, headStart) ∪ [headEnd, recentStart) minus any positions covered
+   * by a pin or document mark.
    */
   protected getCompressibleMessages(store: MessageStoreView): StoredMessage[] {
     const messages = store.getAll();
     const headStart = this.getHeadWindowStartIndex(store);
     const headEnd = this.getHeadWindowEnd(store);
     const recentStart = this.getRecentWindowStart(store);
-    return messages.slice(0, recentStart)
-      .filter((_, i) => i < headStart || i >= headEnd);
+    const pinned = this.pinnedPositions(messages);
+    const out: StoredMessage[] = [];
+    for (let i = 0; i < recentStart; i++) {
+      if (i >= headStart && i < headEnd) continue;
+      if (pinned.has(i)) continue;
+      out.push(messages[i]);
+    }
+    return out;
   }
 
   /**

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -299,12 +299,27 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     }
 
     // Priority 2: Execute pending merges (hierarchical only)
+    //
+    // Peek at the head rather than dequeueing eagerly: dequeueMerge persists
+    // the shorter queue *before* the LLM call leaves the building, so a
+    // transient failure (429, network drop, timeout, executeMerge throw)
+    // would silently lose the merge from disk and the sources would sit at
+    // level N-1 with no mergedInto pointers forever. Commit the removal
+    // only after the merge succeeds; on failure, the queue keeps its entry
+    // and the next tick() retries it.
     if (this.config.hierarchical && this.mergeQueue.length > 0) {
-      const merge = this.dequeueMerge()!;
+      const merge = this.mergeQueue[0]!;
       this.pendingCompression = this.executeMerge(merge.level, merge.sourceIds, ctx);
 
       try {
         await this.pendingCompression;
+        // Success: drop from head and persist the shorter queue. We
+        // re-check that head is still our merge in case some future code
+        // path mutates the queue mid-await (today no other site does,
+        // but the assertion makes that invariant explicit).
+        if (this.mergeQueue[0] === merge) {
+          this.dequeueMerge();
+        }
       } finally {
         this.pendingCompression = null;
       }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export type {
   PhaseType,
   KnowledgeConfig,
   ResettableStrategy,
+  ProtectedRange,
 } from './strategy.js';
 
-export { DEFAULT_AUTOBIOGRAPHICAL_CONFIG, isResettableStrategy } from './strategy.js';
+export { DEFAULT_AUTOBIOGRAPHICAL_CONFIG, isResettableStrategy, isPinnableStrategy } from './strategy.js';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -38,6 +38,15 @@ export type {
   KnowledgeConfig,
   ResettableStrategy,
   ProtectedRange,
+  SearchQuery,
+  SearchResult,
+  SearchableStrategy,
+  PinnableStrategy,
 } from './strategy.js';
 
-export { DEFAULT_AUTOBIOGRAPHICAL_CONFIG, isResettableStrategy, isPinnableStrategy } from './strategy.js';
+export {
+  DEFAULT_AUTOBIOGRAPHICAL_CONFIG,
+  isResettableStrategy,
+  isPinnableStrategy,
+  isSearchableStrategy,
+} from './strategy.js';

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -146,6 +146,28 @@ export function isResettableStrategy(s: ContextStrategy): s is ResettableStrateg
 }
 
 /**
+ * Strategy that supports protected ranges (pins + documents).
+ * Pinned ranges are excluded from compression and render raw at their
+ * original chronological position. Implemented by AutobiographicalStrategy.
+ */
+export interface PinnableStrategy extends ContextStrategy {
+  pinRange(firstMessageId: string, lastMessageId: string, opts?: { name?: string }): string;
+  markDocument(messageId: string, opts?: { name?: string }): string;
+  unpin(pinId: string): boolean;
+  listPins(): ReadonlyArray<ProtectedRange>;
+}
+
+/** Type guard for strategies that support pins / documents. */
+export function isPinnableStrategy(s: ContextStrategy): s is PinnableStrategy {
+  return (
+    'pinRange' in s &&
+    typeof (s as PinnableStrategy).pinRange === 'function' &&
+    'unpin' in s &&
+    typeof (s as PinnableStrategy).unpin === 'function'
+  );
+}
+
+/**
  * Configuration for the Autobiographical strategy.
  */
 export interface AutobiographicalConfig {
@@ -258,6 +280,29 @@ export interface SummaryEntry {
   created: number;
   /** Phase type tag (used by KnowledgeStrategy for asymmetric budget) */
   phaseType?: string;
+}
+
+/**
+ * A range of messages protected from compression. Pins keep a span of raw
+ * messages visible at their original position in the rendered context.
+ *
+ * - `kind: 'pin'` — generic protected range (any first/last span).
+ * - `kind: 'document'` — typically a single message containing a body of
+ *   information the agent wants to retain in full; semantically identical
+ *   to a single-message pin, distinguished by metadata for tooling.
+ */
+export interface ProtectedRange {
+  /** Stable id assigned at pin time. */
+  id: string;
+  /** First message id of the protected range (inclusive). */
+  firstMessageId: string;
+  /** Last message id of the protected range (inclusive). */
+  lastMessageId: string;
+  kind: 'pin' | 'document';
+  /** Optional human-readable label. */
+  name?: string;
+  /** Creation timestamp (ms since epoch). */
+  created: number;
 }
 
 /**

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -168,6 +168,52 @@ export function isPinnableStrategy(s: ContextStrategy): s is PinnableStrategy {
 }
 
 /**
+ * Query for `searchSummaries`. At least one of `text` or `regex` should be
+ * provided to constrain results; otherwise all summaries pass.
+ */
+export interface SearchQuery {
+  /** Case-insensitive substring match against summary content. */
+  text?: string;
+  /** Regex match against summary content (overrides `text` if both set). */
+  regex?: RegExp;
+  /** Filter by summary level(s). Default: all levels. */
+  levels?: SummaryLevel[];
+  /** Maximum number of results to return. Default: 50. */
+  limit?: number;
+  /**
+   * Include summaries that have been merged into a higher-level summary.
+   * Default: false (only "live" unmerged summaries are returned).
+   */
+  includeMerged?: boolean;
+}
+
+/** Result of a single search match. */
+export interface SearchResult {
+  summary: SummaryEntry;
+  /** Number of times the query pattern matched in the summary content. */
+  matches: number;
+}
+
+/**
+ * Strategy that supports searching its summary archive. Implemented by
+ * AutobiographicalStrategy.
+ */
+export interface SearchableStrategy extends ContextStrategy {
+  searchSummaries(query: SearchQuery): SearchResult[];
+  getSummary(id: string): SummaryEntry | null;
+}
+
+/** Type guard for strategies that support search. */
+export function isSearchableStrategy(s: ContextStrategy): s is SearchableStrategy {
+  return (
+    'searchSummaries' in s &&
+    typeof (s as SearchableStrategy).searchSummaries === 'function' &&
+    'getSummary' in s &&
+    typeof (s as SearchableStrategy).getSummary === 'function'
+  );
+}
+
+/**
  * Configuration for the Autobiographical strategy.
  */
 export interface AutobiographicalConfig {

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -246,6 +246,30 @@ export interface AutobiographicalConfig {
    * Only used when `positionedRecallPairs` is true.
    */
   recallHeaderTemplate?: string;
+
+  /**
+   * Per-tool retention limit: keep at most the last N `tool_result` blocks
+   * for each tool name. Older results get their content replaced with a
+   * brief marker referencing the tool name and how many newer results exist.
+   *
+   * Two shapes accepted:
+   *  - `number`: applies as a global default across all tools.
+   *  - `Record<toolName, number>`: per-tool limit; tools not listed are
+   *    unlimited.
+   *
+   * Default: undefined (no pruning). Use a small number (1–5) for tools
+   * that produce verbose, mostly-stale output (e.g. file listings, http
+   * fetches, log queries).
+   */
+  toolResultMaxLastN?: number | Record<string, number>;
+
+  /**
+   * Truncate `tool_use` block inputs whose serialized JSON exceeds this
+   * many tokens. The truncated input becomes `{ "_truncated": true,
+   * "_originalTokens": N }` plus a head slice of the original input
+   * keys for context. Default: 0 (no truncation).
+   */
+  toolUseInputMaxTokens?: number;
 }
 
 /**

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -1,3 +1,4 @@
+import type { JsStore } from '@animalabs/chronicle';
 import type { Membrane } from '@animalabs/membrane';
 import type { StoredMessage, MessageId, Sequence } from './message.js';
 import type { ContextEntry, TokenBudget, PendingWork } from './context.js';
@@ -48,6 +49,22 @@ export interface StrategyContext {
   membrane?: Membrane;
   /** Current sequence number */
   currentSequence: Sequence;
+  /**
+   * Underlying Chronicle store. Strategies may register their own state slots
+   * (via `store.registerState`) for durable strategy state that needs to
+   * survive process restart and follow Chronicle branches.
+   *
+   * State IDs should be scoped under `namespace` to avoid collisions with
+   * other strategies or with the message/context-log states.
+   */
+  store: JsStore;
+  /**
+   * Namespace under which this strategy should scope its state IDs.
+   * Use as a prefix: e.g. `${namespace}/autobio:summaries`. Always defined;
+   * defaults to a stable per-manager value when no caller-supplied namespace
+   * exists, so strategies never need to handle the unscoped case.
+   */
+  namespace: string;
 }
 
 /**

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -270,6 +270,18 @@ export interface AutobiographicalConfig {
    * keys for context. Default: 0 (no truncation).
    */
   toolUseInputMaxTokens?: number;
+
+  /**
+   * Cap on the number of speculative L1 summaries the strategy will hold
+   * (queued + unmerged). When `count(unmerged L1s) + count(queued chunks)`
+   * exceeds this cap, `onNewMessage`'s auto-tick is held back. Chunks
+   * still form and queue, but compression is deferred until a manual
+   * `tick()` or `compile()` triggers it.
+   *
+   * Default: undefined (no cap; compression fires eagerly on every
+   * new message when `autoTickOnNewMessage` is true).
+   */
+  maxSpeculativeL1s?: number;
 }
 
 /**

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -198,6 +198,32 @@ export interface AutobiographicalConfig {
   l2BudgetTokens?: number;
   /** Token budget for L1 summaries in select() (default: 30000) */
   l1BudgetTokens?: number;
+
+  /**
+   * When true (default), each selected summary emits as its own positioned
+   * Q/A recall pair, sorted chronologically by source range. When false,
+   * all selected summaries are concatenated into one Q/A pair between head
+   * and tail (legacy behavior pre-2026-05-10).
+   *
+   * Per-region positioning is the spec-faithful behavior: it lets the agent
+   * see each memory in its temporal place rather than as a wall of unrelated
+   * recollections from another speaker. Without it, hierarchical compression
+   * is structurally similar to the dual-recall corruption pattern that
+   * caused Lena's context degradation on Hermes.
+   */
+  positionedRecallPairs?: boolean;
+
+  /**
+   * Template for the per-pair recall question header. Substitutions:
+   *   {id}    — summary id (e.g. "L1-3")
+   *   {level} — summary level (1, 2, or 3)
+   *   {first} — first source message id
+   *   {last}  — last source message id
+   * Default: '[Recall {id}]'.
+   *
+   * Only used when `positionedRecallPairs` is true.
+   */
+  recallHeaderTemplate?: string;
 }
 
 /**
@@ -296,4 +322,6 @@ Write naturally, as recollection of what you experienced.`,
   summaryContextLabel: 'What do you remember from earlier?',
   summaryParticipant: 'Claude',
   maxMessageTokens: 0,
+  positionedRecallPairs: true,
+  recallHeaderTemplate: '[Recall {id}]',
 };

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -328,6 +328,22 @@ export interface AutobiographicalConfig {
    * new message when `autoTickOnNewMessage` is true).
    */
   maxSpeculativeL1s?: number;
+
+  /**
+   * When false, the rendering pipeline emits the full ideal context (head
+   * window + all selected summaries + all recent messages) without
+   * truncating to fit `budget.maxTokens`. The caller's API will reject if
+   * the result exceeds the model's context window — the philosophy is
+   * "surface the overage rather than silently lose content."
+   *
+   * Default: true (legacy budget-aware truncation: stops emitting recall
+   * pairs and recent messages when the running total exceeds maxTokens).
+   *
+   * Recommended setting for long-lived agents on large-context models
+   * (e.g. opus-4-7 with 1M context): false. The window is generous enough
+   * that overflow is rare, and when it does happen you want to know.
+   */
+  enforceBudget?: boolean;
 }
 
 /**

--- a/test/pins.test.ts
+++ b/test/pins.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for pins / documents / protected ranges (audit gap #3).
+ *
+ * Pinned messages are excluded from compression and render raw at their
+ * original chronological position. Marks survive process restart and follow
+ * Chronicle branches (state is persisted as a snapshot under
+ * `${ns}/autobio:pins`).
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+import type { SummaryEntry } from '../src/types/index.js';
+
+const TEST_STORE_PATH = './test-pins';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+function textBlock(text: string): ContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+class TestableStrategy extends AutobiographicalStrategy {
+  seedL1Against(content: string, firstMsgId: string, lastMsgId: string): SummaryEntry {
+    const entry: SummaryEntry = {
+      id: `L1-${this.nextSummaryIdCounter()}`,
+      level: 1,
+      content,
+      tokens: Math.ceil(content.length / 4),
+      sourceLevel: 0,
+      sourceIds: [firstMsgId, lastMsgId],
+      sourceRange: { first: firstMsgId, last: lastMsgId },
+      created: Date.now(),
+    };
+    this.pushSummary(entry);
+    return entry;
+  }
+
+  // Expose the protected getter for assertions
+  exposeCompressibleIds(store: any): string[] {
+    return this.getCompressibleMessages(store).map((m: any) => m.id);
+  }
+}
+
+describe('AutobiographicalStrategy — pins / documents (gap #3)', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('pinned messages are excluded from the compressible set', async () => {
+    const strategy = new TestableStrategy({ headWindowTokens: 0, recentWindowTokens: 5 });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const m1 = manager.addMessage('user', textBlock('one'));
+    const m2 = manager.addMessage('user', textBlock('two'));
+    const m3 = manager.addMessage('user', textBlock('three'));
+    manager.addMessage('user', textBlock('latest ' + 'X'.repeat(50)));
+
+    // Without any pins, all old messages are compressible.
+    const beforePin = strategy.exposeCompressibleIds((manager as any).messageStore.createView());
+    assert.ok(beforePin.includes(m2), 'm2 should be compressible before pin');
+
+    manager.pinRange(m2, m2);
+
+    const afterPin = strategy.exposeCompressibleIds((manager as any).messageStore.createView());
+    assert.ok(!afterPin.includes(m2), 'm2 must NOT be compressible after pin');
+    assert.ok(afterPin.includes(m1), 'm1 still compressible');
+    assert.ok(afterPin.includes(m3), 'm3 still compressible');
+
+    manager.close();
+  });
+
+  it('renders pinned messages raw at their chronological position', async () => {
+    const strategy = new TestableStrategy({ headWindowTokens: 0, recentWindowTokens: 5 });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const m1 = manager.addMessage('user', textBlock('alpha'));
+    const m2 = manager.addMessage('user', textBlock('PINNED-DOCUMENT-CONTENT'));
+    const m3 = manager.addMessage('user', textBlock('gamma'));
+    manager.addMessage('user', textBlock('latest ' + 'X'.repeat(50)));
+
+    // Seed summaries that cover m1 and m3 (NOT m2 — m2 is pinned).
+    strategy.seedL1Against('summary about alpha', m1, m1);
+    strategy.seedL1Against('summary about gamma', m3, m3);
+
+    manager.markDocument(m2, { name: 'big-doc' });
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+
+    const allTexts = compiled.messages.map(m =>
+      m.content.filter(c => c.type === 'text').map(c => (c as any).text).join('|'),
+    );
+
+    // The pinned message's full content should be rendered raw, not via a summary.
+    const pinIdx = allTexts.findIndex(t => t.includes('PINNED-DOCUMENT-CONTENT'));
+    assert.ok(pinIdx >= 0, 'pinned message text should be visible verbatim in output');
+
+    // The two summaries should also be present.
+    const alphaIdx = allTexts.findIndex(t => t.includes('summary about alpha'));
+    const gammaIdx = allTexts.findIndex(t => t.includes('summary about gamma'));
+    assert.ok(alphaIdx >= 0, 'alpha summary should appear');
+    assert.ok(gammaIdx >= 0, 'gamma summary should appear');
+
+    // Chronological order: alpha summary < pinned m2 < gamma summary
+    assert.ok(alphaIdx < pinIdx, `alpha summary should come before pinned m2 (alpha=${alphaIdx} pin=${pinIdx})`);
+    assert.ok(pinIdx < gammaIdx, `pinned m2 should come before gamma summary (pin=${pinIdx} gamma=${gammaIdx})`);
+
+    manager.close();
+  });
+
+  it('persists pins across close/reopen', async () => {
+    let pinId: string;
+    {
+      const strategy = new TestableStrategy({ headWindowTokens: 0, recentWindowTokens: 5 });
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy,
+      });
+      const m1 = manager.addMessage('user', textBlock('survive me'));
+      manager.addMessage('user', textBlock('latest'));
+
+      pinId = manager.pinRange(m1, m1, { name: 'first-test-pin' });
+      assert.equal(manager.listPins().length, 1);
+      manager.sync();
+      manager.close();
+    }
+    {
+      const strategy = new TestableStrategy({ headWindowTokens: 0, recentWindowTokens: 5 });
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy,
+      });
+      const pins = manager.listPins();
+      assert.equal(pins.length, 1, 'pin should reload from chronicle');
+      assert.equal(pins[0].id, pinId);
+      assert.equal(pins[0].name, 'first-test-pin');
+      manager.close();
+    }
+  });
+
+  it('unpin removes the protection and persists', async () => {
+    const strategy = new TestableStrategy({ headWindowTokens: 0, recentWindowTokens: 5 });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    const m1 = manager.addMessage('user', textBlock('toggle me'));
+    manager.addMessage('user', textBlock('latest'));
+
+    const pinId = manager.pinRange(m1, m1);
+    assert.equal(manager.listPins().length, 1);
+
+    const removed = manager.unpin(pinId);
+    assert.equal(removed, true);
+    assert.equal(manager.listPins().length, 0);
+
+    // Re-unpinning is a no-op (returns false)
+    assert.equal(manager.unpin(pinId), false);
+
+    manager.close();
+  });
+
+  it('multiple pins isolate per Chronicle branch (via fork)', async () => {
+    const strategy = new TestableStrategy({ headWindowTokens: 0, recentWindowTokens: 5 });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const m1 = manager.addMessage('user', textBlock('shared'));
+    manager.addMessage('user', textBlock('latest'));
+    const sharedPin = manager.pinRange(m1, m1, { name: 'shared' });
+
+    const mainBranch = manager.currentBranch().name;
+
+    await manager.fork('experimental');
+    // Adding a pin only on the experimental branch
+    const m2 = manager.addMessage('user', textBlock('only on fork'));
+    manager.addMessage('user', textBlock('latest 2'));
+    const forkPin = manager.pinRange(m2, m2, { name: 'fork-only' });
+
+    assert.equal(manager.listPins().length, 2, 'fork should have shared + fork-only pin');
+
+    await manager.switchBranch(mainBranch);
+    const mainPins = manager.listPins();
+    assert.equal(mainPins.length, 1, 'main should only have the shared pin');
+    assert.equal(mainPins[0].id, sharedPin);
+    assert.ok(!mainPins.some(p => p.id === forkPin), 'main must NOT see the fork-only pin');
+
+    manager.close();
+  });
+});

--- a/test/recall-positioning.test.ts
+++ b/test/recall-positioning.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for per-region recall pair emission (audit gap #2).
+ *
+ * Pre-fix, AutobiographicalStrategy concatenated ALL selected summaries with
+ * `\n\n---\n\n` separators into ONE Q/A pair placed between the head window
+ * and the recent window. Per the spec audit, this is the structural
+ * equivalent of Lena's dual-recall corruption pattern from Hermes: the agent
+ * sees memories as a wall of summaries from another speaker, with no
+ * positional or temporal coherence per individual summary.
+ *
+ * Post-fix, each selected summary emits as its own Q/A recall pair, sorted
+ * chronologically by source-range position. The legacy combined-pair shape
+ * is still available via `positionedRecallPairs: false`.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+import type { SummaryEntry, SummaryLevel } from '../src/types/index.js';
+
+const TEST_STORE_PATH = './test-recall-positioning';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+function textBlock(text: string): ContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+class TestableStrategy extends AutobiographicalStrategy {
+  /** Seed an L1 against a specific source-message id. */
+  seedL1Against(content: string, firstMsgId: string, lastMsgId: string): SummaryEntry {
+    const entry: SummaryEntry = {
+      id: `L1-${this.nextSummaryIdCounter()}`,
+      level: 1,
+      content,
+      tokens: Math.ceil(content.length / 4),
+      sourceLevel: 0,
+      sourceIds: [firstMsgId, lastMsgId],
+      sourceRange: { first: firstMsgId, last: lastMsgId },
+      created: Date.now(),
+    };
+    this.pushSummary(entry);
+    return entry;
+  }
+}
+
+function recallEntries(
+  messages: ReadonlyArray<{ participant: string; content: ContentBlock[] }>,
+): Array<{ q: string; a: string }> {
+  const pairs: Array<{ q: string; a: string }> = [];
+  for (let i = 0; i < messages.length - 1; i++) {
+    const a = messages[i];
+    const b = messages[i + 1];
+    if (a.participant === 'Context Manager') {
+      const q = a.content.map(c => (c.type === 'text' ? c.text : '')).join('');
+      const ans = b.content.map(c => (c.type === 'text' ? c.text : '')).join('');
+      pairs.push({ q, a: ans });
+    }
+  }
+  return pairs;
+}
+
+describe('AutobiographicalStrategy — per-region recall pairs (gap #2)', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('emits one Q/A pair per selected summary, in chronological order', async () => {
+    // recentWindowTokens deliberately small so the three "old" messages we
+    // seed summaries against fall OUTSIDE the recent window — otherwise
+    // anti-redundancy (correctly) hides summaries about messages that are
+    // already shown verbatim in the recent window.
+    const strategy = new TestableStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 8,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    // Three "old" messages whose summaries we'll test, plus one message
+    // big enough to dominate the recent window so the older three fall out.
+    const m1 = manager.addMessage('user', textBlock('first'));
+    const m2 = manager.addMessage('user', textBlock('second'));
+    const m3 = manager.addMessage('user', textBlock('third'));
+    manager.addMessage('user', textBlock('latest message ' + 'X'.repeat(50)));
+
+    // Seed three summaries. Seed in the *opposite* order from chronological
+    // so we can verify the strategy sorts them by source position rather
+    // than by creation order.
+    strategy.seedL1Against('summary about THIRD', m3, m3);
+    strategy.seedL1Against('summary about FIRST', m1, m1);
+    strategy.seedL1Against('summary about SECOND', m2, m2);
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+    const pairs = recallEntries(compiled.messages);
+
+    assert.equal(pairs.length, 3, 'should emit 3 distinct recall pairs');
+
+    // Order should follow source position (m1 < m2 < m3), not seed order.
+    assert.match(pairs[0].a, /FIRST/, 'first pair must cover m1');
+    assert.match(pairs[1].a, /SECOND/, 'second pair must cover m2');
+    assert.match(pairs[2].a, /THIRD/, 'third pair must cover m3');
+
+    // No --- separators (the legacy concat-marker should be gone).
+    for (const p of pairs) {
+      assert.ok(!p.a.includes('---'), `pair ${p.q} unexpectedly contains '---' separator`);
+    }
+
+    manager.close();
+  });
+
+  it('renders the recall header template with summary id by default', async () => {
+    const strategy = new TestableStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 8,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const m1 = manager.addMessage('user', textBlock('foo'));
+    manager.addMessage('user', textBlock('latest ' + 'X'.repeat(50)));
+    const seeded = strategy.seedL1Against('content', m1, m1);
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+    const pairs = recallEntries(compiled.messages);
+
+    assert.equal(pairs.length, 1);
+    assert.equal(pairs[0].q, `[Recall ${seeded.id}]`, 'default template should be [Recall {id}]');
+  });
+
+  it('honors a custom recall header template with all substitutions', async () => {
+    const strategy = new TestableStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 8,
+      recallHeaderTemplate: 'memory {id} (L{level}) covering {first}..{last}',
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const m1 = manager.addMessage('user', textBlock('foo'));
+    const m2 = manager.addMessage('user', textBlock('bar'));
+    manager.addMessage('user', textBlock('latest ' + 'X'.repeat(50)));
+    const seeded = strategy.seedL1Against('content', m1, m2);
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+    const pairs = recallEntries(compiled.messages);
+
+    assert.equal(pairs[0].q, `memory ${seeded.id} (L1) covering ${m1}..${m2}`);
+  });
+
+  it('reverts to combined single-pair shape when positionedRecallPairs is false', async () => {
+    const strategy = new TestableStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 8,
+      positionedRecallPairs: false,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const m1 = manager.addMessage('user', textBlock('a'));
+    const m2 = manager.addMessage('user', textBlock('b'));
+    const m3 = manager.addMessage('user', textBlock('c'));
+    manager.addMessage('user', textBlock('latest ' + 'X'.repeat(50)));
+    strategy.seedL1Against('A', m1, m1);
+    strategy.seedL1Against('B', m2, m2);
+    strategy.seedL1Against('C', m3, m3);
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+    const pairs = recallEntries(compiled.messages);
+
+    assert.equal(pairs.length, 1, 'legacy mode should emit a single combined pair');
+    assert.equal(pairs[0].q, 'What do you remember from earlier?');
+    assert.match(pairs[0].a, /A\n\n---\n\nB\n\n---\n\nC/);
+  });
+
+  it('stops emitting pairs when overall budget would be exceeded', async () => {
+    const strategy = new TestableStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 8,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const m1 = manager.addMessage('user', textBlock('a'));
+    const m2 = manager.addMessage('user', textBlock('b'));
+    const m3 = manager.addMessage('user', textBlock('c'));
+    manager.addMessage('user', textBlock('latest ' + 'X'.repeat(50)));
+
+    // Each summary is ~400 chars (~100 tokens). Three pairs ≈ 300+ tokens of recall.
+    const big = 'X'.repeat(400);
+    strategy.seedL1Against(big + ' first', m1, m1);
+    strategy.seedL1Against(big + ' second', m2, m2);
+    strategy.seedL1Against(big + ' third', m3, m3);
+
+    const compiled = await manager.compile({ maxTokens: 250, reserveForResponse: 0 });
+    const pairs = recallEntries(compiled.messages);
+
+    assert.ok(
+      pairs.length > 0 && pairs.length < 3,
+      `expected partial recall emission under tight budget, got ${pairs.length}`,
+    );
+  });
+});

--- a/test/search.test.ts
+++ b/test/search.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the search API (audit gap #7).
+ *
+ * Substring + regex search over summary content, plus single-summary
+ * lookup by id. Exposed through ContextManager passthrough so callers
+ * (e.g. agent-framework MCPL host) can build `memory_search` /
+ * `memory_read` agent tools on top.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+import type { SummaryEntry, SummaryLevel } from '../src/types/index.js';
+
+const TEST_STORE_PATH = './test-search';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+function textBlock(text: string): ContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+class SeedableStrategy extends AutobiographicalStrategy {
+  seedSummary(content: string, level: SummaryLevel = 1, mergedInto?: string): SummaryEntry {
+    const entry: SummaryEntry = {
+      id: `L${level}-${this.nextSummaryIdCounter()}`,
+      level,
+      content,
+      tokens: Math.ceil(content.length / 4),
+      sourceLevel: 0,
+      sourceIds: ['x'],
+      sourceRange: { first: 'x', last: 'x' },
+      created: Date.now(),
+      ...(mergedInto ? { mergedInto } : {}),
+    };
+    this.pushSummary(entry);
+    return entry;
+  }
+}
+
+describe('AutobiographicalStrategy — search (gap #7)', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('returns empty when no summaries match the substring', async () => {
+    const strategy = new SeedableStrategy();
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    strategy.seedSummary('first memory about cats');
+    strategy.seedSummary('second memory about dogs');
+
+    const results = manager.searchSummaries({ text: 'unicorns' });
+    assert.equal(results.length, 0);
+    manager.close();
+  });
+
+  it('case-insensitive substring search returns matches sorted by hit count', async () => {
+    const strategy = new SeedableStrategy();
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    strategy.seedSummary('a meditation on cats and CATS and cats');  // 3 hits
+    strategy.seedSummary('one note about Cats');                       // 1 hit
+    strategy.seedSummary('something about dogs');                      // 0 hits
+
+    const results = manager.searchSummaries({ text: 'cats' });
+    assert.equal(results.length, 2, 'two summaries should match');
+    assert.equal(results[0].matches, 3, 'highest hit count first');
+    assert.equal(results[1].matches, 1);
+    manager.close();
+  });
+
+  it('regex search supports patterns and counts global matches', async () => {
+    const strategy = new SeedableStrategy();
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    strategy.seedSummary('found errors at 14:23 and 16:45 and 18:00');
+    strategy.seedSummary('no times here');
+
+    const results = manager.searchSummaries({ regex: /\d{2}:\d{2}/ });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].matches, 3, 'should count all 3 timestamps');
+    manager.close();
+  });
+
+  it('level filter restricts to chosen levels', async () => {
+    const strategy = new SeedableStrategy();
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    strategy.seedSummary('shared word here', 1);
+    strategy.seedSummary('shared word also', 2);
+    strategy.seedSummary('shared word too', 3);
+
+    const l2only = manager.searchSummaries({ text: 'shared', levels: [2] });
+    assert.equal(l2only.length, 1);
+    assert.equal(l2only[0].summary.level, 2);
+
+    const l1andL3 = manager.searchSummaries({ text: 'shared', levels: [1, 3] });
+    assert.equal(l1andL3.length, 2);
+    assert.ok(l1andL3.every(r => r.summary.level === 1 || r.summary.level === 3));
+    manager.close();
+  });
+
+  it('excludes merged summaries by default; includeMerged opts in', async () => {
+    const strategy = new SeedableStrategy();
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    strategy.seedSummary('alive content', 1);
+    strategy.seedSummary('folded content', 1, 'L2-99'); // already merged
+
+    const live = manager.searchSummaries({ text: 'content' });
+    assert.equal(live.length, 1, 'merged summaries hidden by default');
+    assert.equal(live[0].summary.content, 'alive content');
+
+    const all = manager.searchSummaries({ text: 'content', includeMerged: true });
+    assert.equal(all.length, 2, 'includeMerged should reveal both');
+    manager.close();
+  });
+
+  it('limit caps the result count', async () => {
+    const strategy = new SeedableStrategy();
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    for (let i = 0; i < 10; i++) {
+      strategy.seedSummary(`hit ${i} hit hit`);
+    }
+    const results = manager.searchSummaries({ text: 'hit', limit: 3 });
+    assert.equal(results.length, 3);
+  });
+
+  it('getSummary returns an entry by id', async () => {
+    const strategy = new SeedableStrategy();
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    const seeded = strategy.seedSummary('lookup me');
+
+    const got = manager.getSummary(seeded.id);
+    assert.ok(got, 'should find the seeded summary');
+    assert.equal(got?.content, 'lookup me');
+    assert.equal(manager.getSummary('nonexistent'), null);
+    manager.close();
+  });
+});

--- a/test/speculation-cap.test.ts
+++ b/test/speculation-cap.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for speculation cap + preflight hook (audit gap #8).
+ *
+ * Pre-fix: every new message triggered an auto-tick that compressed any
+ * pending chunk, regardless of how many speculative L1s the strategy was
+ * already holding. Lena's archive on Hermes ended up with dozens of
+ * speculatively-built L1s before there was any real budget pressure.
+ *
+ * Post-fix:
+ *  - `maxSpeculativeL1s` caps the count of (unmerged L1s + queued chunks).
+ *    When at cap, `onNewMessage` defers auto-tick — chunks still queue,
+ *    but compression doesn't fire until an explicit tick() / compile().
+ *  - `shouldCompressPreflight()` is overridable so subclasses can add
+ *    custom predictive scheduling.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+import type { SummaryEntry, StrategyContext } from '../src/types/index.js';
+
+const TEST_STORE_PATH = './test-speculation-cap';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+function textBlock(text: string): ContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+class TickCountingStrategy extends AutobiographicalStrategy {
+  public tickCalls = 0;
+
+  override async tick(ctx: StrategyContext): Promise<void> {
+    this.tickCalls++;
+    // Do NOT call super.tick — we don't have a real membrane in tests
+    // and we just want to count whether onNewMessage decided to fire.
+  }
+
+  seedL1(content: string): SummaryEntry {
+    const entry: SummaryEntry = {
+      id: `L1-${this.nextSummaryIdCounter()}`,
+      level: 1,
+      content,
+      tokens: Math.ceil(content.length / 4),
+      sourceLevel: 0,
+      sourceIds: ['x'],
+      sourceRange: { first: 'x', last: 'x' },
+      created: Date.now(),
+    };
+    this.pushSummary(entry);
+    return entry;
+  }
+
+  /** True if there's an unprocessed chunk eligible for compression. */
+  hasQueuedChunk(): boolean {
+    return (this as any).compressionQueue.length > 0;
+  }
+}
+
+/**
+ * Add enough small messages to force ≥1 chunk to form in the
+ * compressible region. With targetChunkTokens=20 and chunkOnMessageBoundary,
+ * 5 messages of ~6 tokens each will close one chunk after 4 msgs.
+ */
+async function setupWithQueuedChunk(strategy: TickCountingStrategy): Promise<ContextManager> {
+  const manager = await ContextManager.open({
+    path: TEST_STORE_PATH,
+    strategy,
+  });
+  // recentWindowTokens=5 (small) means only the latest message stays in recent;
+  // the rest are compressible and will form chunks once we hit targetChunkTokens.
+  // 5 padding messages of ~6 tokens, plus one trailing recent message.
+  for (let i = 0; i < 5; i++) {
+    manager.addMessage('user', textBlock(`m-${i} hello world`));
+  }
+  manager.addMessage('user', textBlock('latest one ' + 'X'.repeat(20)));
+  // Wait for any onNewMessage handlers to settle
+  await new Promise(r => setTimeout(r, 30));
+  return manager;
+}
+
+describe('AutobiographicalStrategy — speculation cap (gap #8)', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('default: auto-tick fires whenever a chunk is queued', async () => {
+    const strategy = new TickCountingStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 5,
+      targetChunkTokens: 20,
+      autoTickOnNewMessage: true,
+    });
+    const manager = await setupWithQueuedChunk(strategy);
+
+    assert.ok(strategy.hasQueuedChunk(), 'sanity: chunk should have formed in compressible region');
+    assert.ok(strategy.tickCalls >= 1, `default behavior must auto-tick (got ${strategy.tickCalls})`);
+    manager.close();
+  });
+
+  it('with maxSpeculativeL1s, auto-tick is deferred when at cap', async () => {
+    const strategy = new TickCountingStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 5,
+      targetChunkTokens: 20,
+      autoTickOnNewMessage: true,
+      maxSpeculativeL1s: 2,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    // Seed AFTER open so initialize() doesn't wipe the seeds.
+    strategy.seedL1('summary 1');
+    strategy.seedL1('summary 2');
+    strategy.seedL1('summary 3');
+
+    const ticksBefore = strategy.tickCalls;
+    for (let i = 0; i < 5; i++) {
+      manager.addMessage('user', textBlock(`m-${i} hello world`));
+    }
+    manager.addMessage('user', textBlock('latest one ' + 'X'.repeat(20)));
+    await new Promise(r => setTimeout(r, 30));
+
+    assert.ok(strategy.hasQueuedChunk(), 'sanity: chunk formed');
+    assert.equal(
+      strategy.tickCalls,
+      ticksBefore,
+      'auto-tick must NOT fire when unmerged L1s already exceed maxSpeculativeL1s',
+    );
+    manager.close();
+  });
+
+  it('cap allows auto-tick when count is under the limit', async () => {
+    const strategy = new TickCountingStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 5,
+      targetChunkTokens: 20,
+      autoTickOnNewMessage: true,
+      maxSpeculativeL1s: 5,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+    strategy.seedL1('summary 1');
+
+    const ticksBefore = strategy.tickCalls;
+    for (let i = 0; i < 5; i++) {
+      manager.addMessage('user', textBlock(`m-${i} hello world`));
+    }
+    manager.addMessage('user', textBlock('latest one ' + 'X'.repeat(20)));
+    await new Promise(r => setTimeout(r, 30));
+
+    assert.ok(strategy.hasQueuedChunk(), 'sanity: chunk formed');
+    assert.ok(strategy.tickCalls > ticksBefore, 'auto-tick should fire when under cap');
+    manager.close();
+  });
+
+  it('shouldCompressPreflight=false defers auto-tick', async () => {
+    class DeferAlways extends TickCountingStrategy {
+      protected override shouldCompressPreflight(): boolean { return false; }
+    }
+    const strategy = new DeferAlways({
+      headWindowTokens: 0,
+      recentWindowTokens: 5,
+      targetChunkTokens: 20,
+      autoTickOnNewMessage: true,
+    });
+    const manager = await setupWithQueuedChunk(strategy);
+
+    assert.ok(strategy.hasQueuedChunk(), 'sanity: chunk formed');
+    assert.equal(strategy.tickCalls, 0, 'preflight=false must block auto-tick');
+    manager.close();
+  });
+});

--- a/test/strategy-persistence.test.ts
+++ b/test/strategy-persistence.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for AutobiographicalStrategy persistence + branch fork.
+ *
+ * Strategy state (summaries, summaryIdCounter, mergeQueue) was previously
+ * in-memory only — first process restart wiped the entire L1/L2/L3 pyramid.
+ * Forking the underlying chronicle branch silently shared state across
+ * branches because nothing was actually branch-scoped.
+ *
+ * These tests cover:
+ *  1. restart-and-resume: state survives close/reopen of the same path.
+ *  2. branch fork: a forked branch has its own summary timeline.
+ *  3. branch switch: switching back picks up the right branch's state.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+import type { SummaryEntry, SummaryLevel } from '../src/types/index.js';
+
+const TEST_STORE_PATH = './test-strategy-persistence';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+function textBlock(text: string): ContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+/**
+ * Test subclass that exposes the protected persistence helpers + lets the
+ * test seed summaries through the same code path that production uses.
+ */
+class TestableStrategy extends AutobiographicalStrategy {
+  seedL1(content: string, sourceIds: string[]): SummaryEntry {
+    const entry: SummaryEntry = {
+      id: `L1-${this.nextSummaryIdCounter()}`,
+      level: 1,
+      content,
+      tokens: Math.ceil(content.length / 4),
+      sourceLevel: 0,
+      sourceIds,
+      sourceRange: {
+        first: sourceIds[0] ?? '',
+        last: sourceIds[sourceIds.length - 1] ?? '',
+      },
+      created: Date.now(),
+    };
+    this.pushSummary(entry);
+    return entry;
+  }
+
+  seedL2(sourceL1Ids: string[], content = 'merged'): SummaryEntry {
+    const entry: SummaryEntry = {
+      id: `L2-${this.nextSummaryIdCounter()}`,
+      level: 2,
+      content,
+      tokens: Math.ceil(content.length / 4),
+      sourceLevel: 1,
+      sourceIds: sourceL1Ids,
+      sourceRange: { first: 'a', last: 'z' },
+      created: Date.now(),
+    };
+    this.pushSummary(entry);
+    for (const id of sourceL1Ids) {
+      const src = this.summaries.find(s => s.id === id);
+      if (src) this.setMergedInto(src, entry.id);
+    }
+    return entry;
+  }
+
+  seedMerge(level: SummaryLevel, sourceIds: string[]): void {
+    this.enqueueMerge({ level, sourceIds });
+  }
+
+  // Read-only views for assertions
+  getSummariesView(): SummaryEntry[] { return [...this.summaries]; }
+  getCounter(): number { return this.summaryIdCounter; }
+  getMergeQueueView(): Array<{ level: SummaryLevel; sourceIds: string[] }> {
+    return [...this.mergeQueue];
+  }
+}
+
+describe('AutobiographicalStrategy — persistence', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('restores summaries, counter, and merge queue across close/reopen', async () => {
+    // Phase 1: build state
+    {
+      const strategy = new TestableStrategy({ targetChunkTokens: 300 });
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy,
+      });
+
+      manager.addMessage('User', textBlock('hello'));
+      const m2 = manager.addMessage('Claude', textBlock('hi back'));
+
+      strategy.seedL1('summary one', ['a', 'b']);
+      strategy.seedL1('summary two', ['c', 'd']);
+      strategy.seedMerge(2, ['L1-0', 'L1-1']);
+
+      assert.equal(strategy.getSummariesView().length, 2);
+      assert.equal(strategy.getCounter(), 2);
+      assert.equal(strategy.getMergeQueueView().length, 1);
+
+      manager.sync();
+      manager.close();
+    }
+
+    // Phase 2: reopen, verify reload
+    {
+      const strategy2 = new TestableStrategy({ targetChunkTokens: 300 });
+      const manager2 = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy: strategy2,
+      });
+
+      const summaries = strategy2.getSummariesView();
+      assert.equal(summaries.length, 2, 'summaries should reload from chronicle');
+      assert.equal(summaries[0].content, 'summary one');
+      assert.equal(summaries[1].content, 'summary two');
+      assert.equal(strategy2.getCounter(), 2, 'counter should reload');
+
+      const queue = strategy2.getMergeQueueView();
+      assert.equal(queue.length, 1, 'merge queue should reload');
+      assert.equal(queue[0].level, 2);
+      assert.deepEqual(queue[0].sourceIds, ['L1-0', 'L1-1']);
+
+      manager2.close();
+    }
+  });
+
+  it('persists mergedInto edits so merged sources stay merged after restart', async () => {
+    {
+      const strategy = new TestableStrategy({ targetChunkTokens: 300 });
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy,
+      });
+
+      const a = strategy.seedL1('a', ['m1']);
+      const b = strategy.seedL1('b', ['m2']);
+      const merged = strategy.seedL2([a.id, b.id], 'merged a+b');
+
+      const summaries = strategy.getSummariesView();
+      assert.ok(summaries[0].mergedInto === merged.id);
+      assert.ok(summaries[1].mergedInto === merged.id);
+
+      manager.sync();
+      manager.close();
+    }
+
+    {
+      const strategy = new TestableStrategy({ targetChunkTokens: 300 });
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy,
+      });
+
+      const summaries = strategy.getSummariesView();
+      assert.equal(summaries.length, 3);
+      assert.equal(summaries[0].mergedInto, 'L2-2', 'L1 mergedInto must persist');
+      assert.equal(summaries[1].mergedInto, 'L2-2');
+      assert.equal(summaries[2].mergedInto, undefined);
+
+      manager.close();
+    }
+  });
+
+  it('isolates summary state per chronicle branch (fork)', async () => {
+    const strategy = new TestableStrategy({ targetChunkTokens: 300 });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    // Build pre-fork state, then fork at current head so the forked branch
+    // inherits everything we've written so far.
+    manager.addMessage('User', textBlock('m1'));
+    manager.addMessage('Claude', textBlock('m2'));
+    strategy.seedL1('common L1 (pre-fork)', ['m1', 'm2']);
+
+    const mainBranchName = manager.currentBranch().name;
+
+    const forkedName = await manager.fork('experimental');
+    assert.equal(forkedName, 'experimental');
+    assert.notEqual(forkedName, mainBranchName);
+
+    // On the forked branch, add a divergent summary
+    const strategyAfterFork = manager.getStrategy() as TestableStrategy;
+    assert.equal(
+      strategyAfterFork.getSummariesView().length,
+      1,
+      'forked branch should start with the pre-fork summary',
+    );
+    strategyAfterFork.seedL1('divergent on fork', ['x', 'y']);
+    assert.equal(strategyAfterFork.getSummariesView().length, 2);
+
+    // Switch back to main: should see only the pre-fork summary
+    await manager.switchBranch(mainBranchName);
+    const mainStrategy = manager.getStrategy() as TestableStrategy;
+    const mainSummaries = mainStrategy.getSummariesView();
+    assert.equal(
+      mainSummaries.length,
+      1,
+      'main branch must NOT see summaries created on fork',
+    );
+    assert.equal(mainSummaries[0].content, 'common L1 (pre-fork)');
+
+    // Add a summary unique to main
+    mainStrategy.seedL1('unique to main', ['p', 'q']);
+    assert.equal(mainStrategy.getSummariesView().length, 2);
+
+    // Switch back to fork: should still have its own divergent state
+    await manager.switchBranch(forkedName);
+    const forkStrategy = manager.getStrategy() as TestableStrategy;
+    const forkSummaries = forkStrategy.getSummariesView();
+    assert.equal(forkSummaries.length, 2, 'fork branch should still have 2 summaries');
+    assert.equal(forkSummaries[1].content, 'divergent on fork');
+    assert.ok(
+      !forkSummaries.some(s => s.content === 'unique to main'),
+      'fork must not see main-only summary',
+    );
+
+    manager.close();
+  });
+});

--- a/test/strategy-persistence.test.ts
+++ b/test/strategy-persistence.test.ts
@@ -231,4 +231,78 @@ describe('AutobiographicalStrategy — persistence', () => {
 
     manager.close();
   });
+
+  it('keeps merge queue intact when executeMerge throws (no eager dequeue)', async () => {
+    // Regression test for the eager-dequeue footgun: dequeueMerge() used to
+    // run *before* the LLM call, so a transient failure (429, network drop,
+    // timeout) would silently drop the merge from the persisted queue
+    // forever. The fix is peek + shift-on-success — these assertions lock
+    // that contract in.
+    class FailingMergeStrategy extends TestableStrategy {
+      executeMergeError = new Error('simulated LLM failure');
+
+      protected override async executeMerge(
+        _level: SummaryLevel,
+        _sourceIds: string[],
+        _ctx: import('../src/types/index.js').StrategyContext,
+      ): Promise<void> {
+        throw this.executeMergeError;
+      }
+    }
+
+    const stubMembrane = {} as unknown as import('@animalabs/membrane').Membrane;
+
+    // Phase 1: enqueue a merge, force tick to fail, verify queue intact
+    {
+      const strategy = new FailingMergeStrategy({
+        targetChunkTokens: 300,
+        hierarchical: true,
+      });
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy,
+        membrane: stubMembrane,
+      });
+
+      strategy.seedMerge(2, ['L1-0', 'L1-1']);
+      assert.equal(strategy.getMergeQueueView().length, 1, 'merge enqueued');
+
+      // tick() will pick up the merge, invoke (our failing) executeMerge,
+      // and surface the error. The queue must still be intact afterward.
+      await assert.rejects(
+        () => manager.tick(),
+        /simulated LLM failure/,
+        'tick should propagate the LLM failure',
+      );
+
+      const queue = strategy.getMergeQueueView();
+      assert.equal(queue.length, 1, 'merge MUST remain in queue after failure');
+      assert.equal(queue[0].level, 2);
+      assert.deepEqual(queue[0].sourceIds, ['L1-0', 'L1-1']);
+
+      manager.sync();
+      manager.close();
+    }
+
+    // Phase 2: reopen the store; the un-merged entry must still be there.
+    // This is the part that mattered most pre-fix — the failure was *durable*
+    // because dequeueMerge persisted the shorter queue before the LLM call.
+    {
+      const strategy = new TestableStrategy({
+        targetChunkTokens: 300,
+        hierarchical: true,
+      });
+      const manager = await ContextManager.open({
+        path: TEST_STORE_PATH,
+        strategy,
+      });
+
+      const queue = strategy.getMergeQueueView();
+      assert.equal(queue.length, 1, 'merge MUST survive close/reopen');
+      assert.equal(queue[0].level, 2);
+      assert.deepEqual(queue[0].sourceIds, ['L1-0', 'L1-1']);
+
+      manager.close();
+    }
+  });
 });

--- a/test/tool-pruning.test.ts
+++ b/test/tool-pruning.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for tool-result pruning + tool_use input truncation (audit gap #4).
+ *
+ * For tool-heavy sessions, dozens or hundreds of repeated tool calls can
+ * dominate context. This pruning pass keeps the most recent N results per
+ * tool name (older ones get a brief marker), and optionally truncates
+ * tool_use input blobs whose serialized JSON exceeds a token cap.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-tool-pruning';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+function toolUse(id: string, name: string, input: Record<string, unknown>): ContentBlock {
+  return { type: 'tool_use', id, name, input };
+}
+function toolResult(id: string, content: string): ContentBlock {
+  return { type: 'tool_result', toolUseId: id, content };
+}
+
+describe('AutobiographicalStrategy — tool pruning (gap #4)', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('keeps last N tool_results per tool, replacing older ones with a marker', async () => {
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 100_000, // keep all in recent for this test
+      toolResultMaxLastN: { 'fs:read': 2 }, // keep last 2 fs:read results
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    // Five tool_use+tool_result pairs for 'fs:read', plus one for 'http:get'.
+    for (let i = 0; i < 5; i++) {
+      const id = `tu-${i}`;
+      manager.addMessage('Claude', [toolUse(id, 'fs:read', { path: `/file${i}` })]);
+      manager.addMessage('user', [toolResult(id, `<file ${i} content here, pretend it is verbose>`)]);
+    }
+    manager.addMessage('Claude', [toolUse('tu-http', 'http:get', { url: 'x' })]);
+    manager.addMessage('user', [toolResult('tu-http', 'HTTP body')]);
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+
+    const allBlocks = compiled.messages.flatMap(m => m.content);
+    const fsResults = allBlocks.filter(
+      (b): b is { type: 'tool_result'; toolUseId: string; content: string } =>
+        b.type === 'tool_result' && b.toolUseId.startsWith('tu-') && b.toolUseId !== 'tu-http',
+    );
+    assert.equal(fsResults.length, 5, 'all 5 fs:read tool_result blocks should still be present (just rewritten)');
+
+    const truncated = fsResults.filter(r => typeof r.content === 'string' && r.content.includes('Result truncated'));
+    const intact = fsResults.filter(r => typeof r.content === 'string' && r.content.includes('file '));
+
+    assert.equal(truncated.length, 3, 'first 3 should be truncated (older)');
+    assert.equal(intact.length, 2, 'last 2 should survive intact');
+
+    // The last two intact ones must be tu-3 and tu-4 (most recent).
+    const intactIds = intact.map(r => r.toolUseId).sort();
+    assert.deepEqual(intactIds, ['tu-3', 'tu-4']);
+
+    // http:get result has no limit configured, so it stays intact.
+    const httpResult = allBlocks.find(
+      (b): b is { type: 'tool_result'; toolUseId: string; content: string } =>
+        b.type === 'tool_result' && b.toolUseId === 'tu-http',
+    );
+    assert.ok(httpResult);
+    assert.equal(httpResult.content, 'HTTP body', 'http:get untouched (no limit)');
+
+    manager.close();
+  });
+
+  it('global numeric cap applies to all tools', async () => {
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 100_000,
+      toolResultMaxLastN: 1, // keep only the most recent result per tool, period
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    for (let i = 0; i < 3; i++) {
+      manager.addMessage('Claude', [toolUse(`a-${i}`, 'tool-a', { i })]);
+      manager.addMessage('user', [toolResult(`a-${i}`, `result-a-${i}`)]);
+      manager.addMessage('Claude', [toolUse(`b-${i}`, 'tool-b', { i })]);
+      manager.addMessage('user', [toolResult(`b-${i}`, `result-b-${i}`)]);
+    }
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+    const allBlocks = compiled.messages.flatMap(m => m.content);
+    const intactA = allBlocks.filter(
+      (b): b is { type: 'tool_result'; toolUseId: string; content: string } =>
+        b.type === 'tool_result' && b.toolUseId.startsWith('a-') && typeof b.content === 'string' && b.content.startsWith('result-'),
+    );
+    const intactB = allBlocks.filter(
+      (b): b is { type: 'tool_result'; toolUseId: string; content: string } =>
+        b.type === 'tool_result' && b.toolUseId.startsWith('b-') && typeof b.content === 'string' && b.content.startsWith('result-'),
+    );
+
+    assert.equal(intactA.length, 1, 'only 1 result-a survives (global cap=1)');
+    assert.equal(intactB.length, 1, 'only 1 result-b survives');
+    assert.equal(intactA[0].toolUseId, 'a-2', 'most recent a survives');
+    assert.equal(intactB[0].toolUseId, 'b-2', 'most recent b survives');
+  });
+
+  it('truncates oversized tool_use input when toolUseInputMaxTokens is set', async () => {
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 100_000,
+      toolUseInputMaxTokens: 10, // ~40 chars
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    manager.addMessage('Claude', [
+      toolUse('x', 'fs:write', {
+        path: '/very-long-file-name.txt',
+        content: 'X'.repeat(2000), // ≈ 500 tokens — well over cap
+        encoding: 'utf-8',
+      }),
+    ]);
+    manager.addMessage('user', [toolResult('x', 'ok')]);
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+    const useBlock = compiled.messages
+      .flatMap(m => m.content)
+      .find((b): b is { type: 'tool_use'; id: string; name: string; input: Record<string, unknown> } => b.type === 'tool_use');
+    assert.ok(useBlock);
+
+    assert.equal(useBlock.input._truncated, true, 'input must be flagged as truncated');
+    assert.ok(typeof useBlock.input._originalTokens === 'number');
+    assert.ok(Array.isArray(useBlock.input._keys));
+    // The original keys list should have been preserved as a hint
+    assert.ok((useBlock.input._keys as string[]).includes('path'));
+    assert.ok((useBlock.input._keys as string[]).includes('content'));
+
+    // The original `content` body must be GONE (this is the whole point)
+    assert.equal((useBlock.input as Record<string, unknown>).content, undefined);
+  });
+
+  it('does nothing when both pruning configs are unset (default)', async () => {
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 100_000,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    for (let i = 0; i < 4; i++) {
+      manager.addMessage('Claude', [toolUse(`t-${i}`, 'unused', { i })]);
+      manager.addMessage('user', [toolResult(`t-${i}`, `body-${i}`)]);
+    }
+
+    const compiled = await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+    const allBlocks = compiled.messages.flatMap(m => m.content);
+    const intact = allBlocks.filter(
+      b => b.type === 'tool_result' && typeof (b as any).content === 'string' && ((b as any).content as string).startsWith('body-'),
+    );
+    assert.equal(intact.length, 4, 'all results untouched when no pruning configured');
+  });
+});


### PR DESCRIPTION
## Summary

- `AutobiographicalStrategy` now persists its L1/L2/L3 summary pyramid, ID counter, and pending merge queue to Chronicle. Previously these were instance-only — a process restart wiped everything (the message archive survived, but the summaries — the product of expensive LLM calls — were lost).
- Strategy state is **branch-aware**: switching branches re-loads strategy state for the new branch, and `fork()` creates an isolated alternate timeline.
- Pluggable strategies in general can now hold durable state via the new `StrategyContext.store` + `namespace`. Other strategies (KnowledgeStrategy, FrontdeskStrategy in connectome-host) inherit persistence with no changes because they don't override the mutation paths.

## What changed

**Interface (`StrategyContext`)**
- Adds required `store: JsStore` and `namespace: string`. Strategies use these to register their own state slots and persist their own data.

**`ContextManager`**
- `switchBranch` is now async; re-initializes the strategy after switching.
- New `fork(name?)`: creates a branch at the current head, switches to it, returns the new branch name. Distinct from time-travel `branchAt(messageId)`.
- `branchAt` now returns the new branch *name* (not the internal id). The id was unusable — `switchBranch` requires a name — so any caller passing the prior return value into `switchBranch` was already broken.

**`AutobiographicalStrategy`**
- Three Chronicle states per namespace:
  - `{ns}/autobio:summaries` — AppendLog of `SummaryEntry`
  - `{ns}/autobio:counter`   — Snapshot of the next-id counter
  - `{ns}/autobio:mergeQueue` — Snapshot of pending merges
- All mutation routes through new helpers (`pushSummary`, `setMergedInto`, `nextSummaryIdCounter`, `enqueueMerge`, `dequeueMerge`) so subclasses inherit persistence cleanly.
- `initialize()` registers states (idempotent) and reloads.

## Breaking changes

1. `StrategyContext` now requires `store` and `namespace`. All in-tree strategies and tests go through `ContextManager.open()` which provides them — no caller changes needed in this repo.
2. `ContextManager.switchBranch` is now async (`Promise<void>` instead of `void`). Callers must `await`.
3. `ContextManager.branchAt` returns the new branch's *name* instead of the internal numeric id. The previous return value couldn't be fed back into `switchBranch`, so this is fixing a latent bug.

## Test plan

- [x] `test/strategy-persistence.test.ts` (new): restart-and-resume, mergedInto edits across restart, fork-with-isolated-state
- [x] Full suite: 86/86 pass (was 83; +3 new)
- [ ] Downstream verification: agent-framework + connectome-host (separate PRs to come — both consume strategies via ContextManager.open and don't reference the changed surface, so the dep-bump should be clean)

## Crash-recovery note

In `executeMerge`, the order is: persist new entry → persist `mergedInto` edits on each source. If the process crashes between the two, restart sees the new entry plus a partial set of marked sources. Un-marked sources would re-trigger a merge, producing a duplicate higher-level entry on rare crash boundaries. The trade-off is duplication over data-loss; flagged inline. A self-healing pass on `initialize()` could be added later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)