### PR TITLE
review-followup: PR #15 findings (1) and (2) — uncompressed raw-fallback + RenderStats type guard

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -20,7 +20,8 @@ import type {
   SearchResult,
   SummaryEntry,
 } from './types/index.js';
-import { isResettableStrategy, isPinnableStrategy, isSearchableStrategy } from './types/index.js';
+import { isResettableStrategy, isPinnableStrategy, isSearchableStrategy, isRenderStatsCapable } from './types/index.js';
+import type { RenderStats } from './types/index.js';
 import { MessageStore, MessageStoreEvent } from './message-store.js';
 import { ContextLog } from './context-log.js';
 import { PassthroughStrategy } from './strategies/passthrough.js';
@@ -651,19 +652,9 @@ export class ContextManager {
    * Designed for TUIs / dashboards that want to display "how much of the
    * agent's context is folded vs raw" at a glance.
    */
-  getRenderStats(): {
-    head: { messages: number; tokens: number };
-    tail: { messages: number; tokens: number };
-    summaries: {
-      l1: { count: number; tokens: number };
-      l2: { count: number; tokens: number };
-      l3: { count: number; tokens: number };
-    };
-    pending: { chunks: number; merges: number };
-  } | null {
-    const fn = (this.strategy as { getRenderStats?: (s: unknown) => unknown }).getRenderStats;
-    if (typeof fn !== 'function') return null;
-    return fn.call(this.strategy, this.messageStore.createView()) as ReturnType<NonNullable<typeof this.getRenderStats>>;
+  getRenderStats(): RenderStats | null {
+    if (!isRenderStatsCapable(this.strategy)) return null;
+    return this.strategy.getRenderStats(this.messageStore.createView());
   }
 
   /**

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1332,13 +1332,50 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     // Pinned messages between head and recent (head/recent pinned ones
     // already emit raw via Phase 0 / Phase 4).
     const pinnedInMiddle: { msg: StoredMessage; position: number }[] = [];
+    const pinnedIdsInMiddle = new Set<string>();
     for (let i = headEnd; i < recentStart; i++) {
       if (pinnedPositionsSet.has(i)) {
         pinnedInMiddle.push({ msg: messages[i], position: i });
+        pinnedIdsInMiddle.add(messages[i].id);
       }
     }
 
-    if (selectedSummaries.length > 0 || pinnedInMiddle.length > 0) {
+    // Uncompressed-chunk fallback: messages in the middle region whose
+    // chunk hasn't been summarized yet. Without this, a message that
+    // rolled out of the recent window into a queued-but-not-yet-compressed
+    // chunk would vanish from rendered context — there'd be no summary to
+    // emit (compression hasn't run) and Phase 4 only walks recentStart
+    // onwards. Mirrors selectLegacy's "Uncompressed: emit raw" behavior
+    // around line 738, but here we interleave chronologically with
+    // summaries and pins via the unified items list below.
+    //
+    // This matters because compile() was made non-blocking in commit
+    // `3e42e98` (drops the prior `await readiness.pendingWork`); without
+    // this fallback, the trade was silent data-loss for messages caught
+    // in the queued-but-not-yet-compressed window. Now compile()'s
+    // freshness contract is: summaries may lag the very latest L1, but
+    // no message ever disappears.
+    const uncompressedInMiddle: { msg: StoredMessage; position: number }[] = [];
+    for (const chunk of this.chunks) {
+      if (chunk.compressed) continue;
+      for (const msg of chunk.messages) {
+        const pos = positionOf.get(msg.id);
+        if (pos === undefined) continue;
+        if (pos < headEnd || pos >= recentStart) continue;
+        if (pinnedIdsInMiddle.has(msg.id)) continue;
+        uncompressedInMiddle.push({ msg, position: pos });
+      }
+    }
+
+    // Merged list of raw messages to emit in the middle region —
+    // either a pin or a message whose chunk hasn't compressed yet.
+    // Both render identically (raw, at their chronological position).
+    const middleRaw: { msg: StoredMessage; position: number }[] = [
+      ...pinnedInMiddle,
+      ...uncompressedInMiddle,
+    ];
+
+    if (selectedSummaries.length > 0 || middleRaw.length > 0) {
       const summaryParticipant = this.config.summaryParticipant ?? 'Claude';
 
       if (this.config.positionedRecallPairs !== false) {
@@ -1352,7 +1389,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
           const pos = positionOf.get(s.sourceRange.first) ?? Number.MAX_SAFE_INTEGER;
           items.push({ kind: 'summary', position: pos, summary: s });
         }
-        for (const p of pinnedInMiddle) {
+        for (const p of middleRaw) {
           items.push({ kind: 'pin', position: p.position, msg: p.msg });
         }
         items.sort((a, b) => a.position - b.position);
@@ -1431,7 +1468,10 @@ export class AutobiographicalStrategy implements ResettableStrategy {
           totalTokens += pairTokens;
         }
 
-        for (const { msg } of pinnedInMiddle) {
+        // Sort by position so uncompressed-middle messages and pins both
+        // appear in their chronological place after the combined recall pair.
+        const middleRawSorted = [...middleRaw].sort((a, b) => a.position - b.position);
+        for (const { msg } of middleRawSorted) {
           const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
           const tokens = msgCap > 0
             ? Math.min(store.estimateTokens(msg), msgCap + 50)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,6 +42,8 @@ export type {
   SearchResult,
   SearchableStrategy,
   PinnableStrategy,
+  RenderStats,
+  RenderStatsCapableStrategy,
 } from './strategy.js';
 
 export {
@@ -49,4 +51,5 @@ export {
   isResettableStrategy,
   isPinnableStrategy,
   isSearchableStrategy,
+  isRenderStatsCapable,
 } from './strategy.js';

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -214,6 +214,41 @@ export function isSearchableStrategy(s: ContextStrategy): s is SearchableStrateg
 }
 
 /**
+ * Per-render observability stats from a strategy. Counts and token sums for
+ * head / tail / summaries / pending work, suitable for TUIs and dashboards
+ * that want to display "how much of the context is folded vs raw" at a
+ * glance. Token sums use the strategy's own estimates so they line up with
+ * the numbers `select()` uses for budget math.
+ */
+export interface RenderStats {
+  head: { messages: number; tokens: number };
+  tail: { messages: number; tokens: number };
+  summaries: {
+    l1: { count: number; tokens: number };
+    l2: { count: number; tokens: number };
+    l3: { count: number; tokens: number };
+  };
+  pending: { chunks: number; merges: number };
+}
+
+/**
+ * Strategy that can produce render-time observability stats. Implemented by
+ * AutobiographicalStrategy. Optional capability — strategies that don't
+ * implement it simply have `ContextManager.getRenderStats()` return `null`.
+ */
+export interface RenderStatsCapableStrategy extends ContextStrategy {
+  getRenderStats(store: MessageStoreView): RenderStats;
+}
+
+/** Type guard for strategies that produce render stats. */
+export function isRenderStatsCapable(s: ContextStrategy): s is RenderStatsCapableStrategy {
+  return (
+    'getRenderStats' in s &&
+    typeof (s as RenderStatsCapableStrategy).getRenderStats === 'function'
+  );
+}
+
+/**
  * Configuration for the Autobiographical strategy.
  */
 export interface AutobiographicalConfig {

--- a/test/non-blocking-compile.test.ts
+++ b/test/non-blocking-compile.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for `compile()`'s non-blocking contract + the uncompressed-chunk
+ * fallback that prevents silent message loss.
+ *
+ * Background: commit `3e42e98` dropped the `await readiness.pendingWork`
+ * inside `compile()` to keep turn latency low (compression can take
+ * 30+s; awaiting it per-turn was the wrong tradeoff). The side effect
+ * was that messages caught in a queued-but-not-yet-compressed chunk
+ * would vanish from rendered context in hierarchical mode — no summary
+ * existed yet for the chunk, and `selectHierarchical` only emitted raw
+ * messages from `recentStart` onward.
+ *
+ * The fix (these tests pin in place): `selectHierarchical` now emits
+ * raw messages for any uncompressed chunk that overlaps the middle
+ * region between the head and recent windows, mirroring
+ * `selectLegacy`'s "Uncompressed: emit raw" behavior. Once compression
+ * finishes and the chunk transitions to `compressed: true`, the raw
+ * emission stops (the chunk is now covered by an L1 summary), so
+ * there's no double-counting across the transition.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-non-blocking-compile';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+function textBlock(text: string): ContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+function compiledHas(
+  compiled: { messages: ReadonlyArray<{ content: ContentBlock[] }> },
+  fragment: string,
+): boolean {
+  for (const m of compiled.messages) {
+    for (const block of m.content) {
+      if (block.type === 'text' && block.text.includes(fragment)) return true;
+    }
+  }
+  return false;
+}
+
+describe('AutobiographicalStrategy — non-blocking compile + uncompressed-chunk fallback', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('emits raw messages for uncompressed chunks in the middle region (no silent drop)', async () => {
+    // Configure for a small middle region:
+    //  - No head window (so all messages compete for visibility via the
+    //    summary path and the recent window).
+    //  - Small recentWindowTokens so older messages fall out of recent.
+    //  - Small targetChunkTokens so a single old message ends up in
+    //    its own chunk.
+    //  - Hierarchical mode so `selectHierarchical` is the codepath
+    //    under test (selectLegacy already had this fallback).
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 12,
+      targetChunkTokens: 4,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    // Three "old" messages whose chunks will be queued but un-ticked,
+    // plus a "latest" big enough to dominate the small recent window.
+    manager.addMessage('user', textBlock('ANCIENT_MARKER_1'));
+    manager.addMessage('user', textBlock('ANCIENT_MARKER_2'));
+    manager.addMessage('user', textBlock('ANCIENT_MARKER_3'));
+    manager.addMessage('user', textBlock('LATEST ' + 'X'.repeat(80)));
+
+    // Critically: we do NOT call manager.tick(). The chunks for the
+    // ancient messages exist in the strategy's compression queue but
+    // never run through executeMerge/compressChunk, so they stay
+    // `chunk.compressed === false`. This is the exact state where the
+    // bug used to silently drop messages.
+    const compiled = await manager.compile({
+      maxTokens: 100_000,
+      reserveForResponse: 0,
+    });
+
+    assert.ok(
+      compiledHas(compiled, 'ANCIENT_MARKER_1'),
+      'ANCIENT_MARKER_1 must appear in compiled output (uncompressed-chunk fallback)',
+    );
+    assert.ok(
+      compiledHas(compiled, 'ANCIENT_MARKER_2'),
+      'ANCIENT_MARKER_2 must appear in compiled output',
+    );
+    assert.ok(
+      compiledHas(compiled, 'ANCIENT_MARKER_3'),
+      'ANCIENT_MARKER_3 must appear in compiled output',
+    );
+    // The recent message must of course still be there.
+    assert.ok(
+      compiledHas(compiled, 'LATEST'),
+      'LATEST message must appear in compiled output',
+    );
+
+    manager.close();
+  });
+
+  it('compile() returns promptly without awaiting pending compression', async () => {
+    // Sanity check on the freshness contract change: compile() must
+    // not block on `pendingCompression`. We can't easily inject a slow
+    // mock LLM here, but we *can* assert that compile() completes
+    // before any tick would have time to finish.
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 12,
+      targetChunkTokens: 4,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    manager.addMessage('user', textBlock('older'));
+    manager.addMessage('user', textBlock('latest ' + 'Y'.repeat(80)));
+
+    const t0 = Date.now();
+    await manager.compile({ maxTokens: 100_000, reserveForResponse: 0 });
+    const elapsed = Date.now() - t0;
+
+    // No LLM, no real awaiting — compile should be effectively instant.
+    // 500ms is wildly generous; the actual time is sub-10ms in practice.
+    assert.ok(
+      elapsed < 500,
+      `compile() should return promptly; took ${elapsed}ms`,
+    );
+
+    manager.close();
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to [#15](https://github.com/anima-research/context-manager/pull/15) addressing Anarchid's two blocking findings, which were missed because #15 was merged ~2 min before these commits were authored. Both commits already lived on the (now-merged) `feature/autobio-spec-gaps` branch and pass tests there; this PR brings them onto `main`.

- **Finding (1)** — `compile()` is non-blocking (per `3e42e98`), but `selectHierarchical` never emitted raw messages for uncompressed chunks. Result: messages caught in the queued-but-not-yet-compressed window vanished from rendered context in hierarchical mode. `selectLegacy` already handled this case ("Uncompressed: emit raw messages so they aren't lost"); this commit brings the hierarchical path to parity by emitting raw at the chronological position, interleaved with summaries and pins. Once compression completes (`chunk.compressed=true`), the chunk is covered by an L1 summary and the raw emission stops — no double-counting across the transition.

- **Finding (2)** — `ContextManager.getRenderStats` used an untyped `as { getRenderStats?: ... }` cast three lines from where #15 established the type-guard pattern for pins and search. Extracts `RenderStats` + `RenderStatsCapableStrategy` + `isRenderStatsCapable` into `src/types/strategy.ts` (re-exported via `types/index.ts`) and uses the guard like its siblings. No behavior change; `AutobiographicalStrategy`'s inline return type already satisfies the new interface structurally.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 114 pass / 0 fail / 0 cancelled (was 112 on prior PR #15 HEAD; +2 new tests from finding 1)
  - New `test/non-blocking-compile.test.ts`:
    - asserts ANCIENT_MARKER_{1,2,3} messages survive `compile()` when their chunks are queued but not yet compressed
    - asserts `compile()` returns promptly (<500ms) without awaiting compression
- [ ] Manual: live verification with Lena that hierarchical-mode turns include the previously-dropped messages (covered by the regression test above, but a real-runtime sanity check is cheap)

## Anarchid's other findings on #15

Not addressed in this PR (to keep it surgical to the two blockers):
- (3) PR description rewrite — already merged, can't be amended retroactively
- (4)–(11) MEH findings (no tests for bonus features, `pinRange` ID validation, hardcoded compression-model literal, dead helper, etc.) — leaving as follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)