### PR TITLE
fix: MessageStore.get returns slot index as sequence — silently corrupts branchAt

### DIFF
--- a/src/message-store.ts
+++ b/src/message-store.ts
@@ -457,11 +457,22 @@ export class MessageStore {
   private internalToStored(
     internal: StoredMessageInternal,
     id: MessageId,
-    index: number
+    _index: number,
   ): StoredMessage {
     return {
       id,
-      sequence: index, // Use index as sequence for now
+      // chronicle record sequence captured when the message was appended
+      // (see `add()` line 131: `sequence: record.sequence`). The previous
+      // implementation returned the slot index ("// Use index as sequence
+      // for now"), which silently corrupted any downstream code that
+      // forwarded this number to chronicle APIs expecting a real sequence
+      // — most notably `ContextManager.branchAt`, which would fork the
+      // chronicle at the index-mistaken-for-sequence and lose every
+      // record between the intended fork point and the actual one. For
+      // typical autobio sessions the index-vs-sequence ratio is ~1:2
+      // (each message append is accompanied by ~1 autobio state update),
+      // so /undo of a 800-message conversation forked ~400 messages back.
+      sequence: internal.sequence,
       participant: internal.participant,
       content: this.blobManager.resolveBlobs(internal.content),
       metadata: internal.metadata,

--- a/src/message-store.ts
+++ b/src/message-store.ts
@@ -125,18 +125,42 @@ export class MessageStore {
     const record = this.store.appendToStateJson(this.stateId, partialInternal);
     const index = this.length() - 1;
 
-    // Now update the stored item to include the id (for rebuildIndex)
+    // The append's payload doesn't carry the chronicle record's id /
+    // sequence — those are only known once the append returns. We patch
+    // them in via editStateItem below. The patch creates a new chronicle
+    // record at `record.sequence + 1` (the next sequence; nothing else
+    // writes between the append and the edit inside this function).
+    //
+    // We store the EDIT'S sequence (not the original append's) as the
+    // canonical "this message is fully readable at and after this seq"
+    // marker. Why: `ContextManager.branchAt(messageId)` forwards
+    // `message.sequence` to `chronicle.createBranchAt`, which forks
+    // visibility at that exact seq. If `sequence` pointed at the original
+    // append (record.sequence), the new branch would see the pre-patch
+    // payload (id/sequence undefined). Pointing at the edit's seq
+    // includes the patched payload in the inherited records — so a
+    // forked branch sees this message in its fully-established form.
+    //
+    // Invariant: this function does exactly ONE chronicle write between
+    // the append and the edit (the edit itself). If that ever changes,
+    // the +1 expression must be updated to match (or refactored to
+    // capture editStateItem's returned record.sequence — which is
+    // chicken-and-egg here since we need the value inside the payload
+    // we're writing).
+    const commitSequence = record.sequence + 1;
     const fullInternal: StoredMessageInternal = {
       id: record.id,
-      sequence: record.sequence,
+      sequence: commitSequence,
       ...partialInternal,
     };
     this.store.editStateItem(this.stateId, index, Buffer.from(JSON.stringify(fullInternal)));
 
-    // Build full message with ID and sequence from record
+    // Build full message with ID and sequence from record. The sequence
+    // we expose is the commit sequence (matches what's stored), so
+    // `branchAt(messageId)` forks at the right place for any caller.
     const message: StoredMessage = {
       id: record.id,
-      sequence: record.sequence,
+      sequence: commitSequence,
       participant,
       content, // Original content with inline data
       metadata,

--- a/test/message-store-sequence.test.ts
+++ b/test/message-store-sequence.test.ts
@@ -130,20 +130,90 @@ describe('MessageStore — sequence semantics', () => {
       `forked branch must see exactly 5 messages, got ${onBranch.length}. ` +
         'A smaller count means branchAt forked at the slot index instead of the chronicle sequence.',
     );
-    // Verify the contents are the first 5 messages, in order. (We don't
-    // assert `onBranch[N-1].id === ids[4]` because of a separate bug:
-    // MessageStore.add() appends a partial record then patches in id/seq
-    // via a follow-up editStateItem, so the fork-point message's id/seq
-    // are inherited pre-patch on the new branch. Tracked as a follow-up;
-    // doesn't affect this test's invariant — the count is the part that
-    // matters for the original /undo regression.)
+    // Verify the contents AND that fork-point message has full id/sequence
+    // (not undefined). Pre-fix #2, the fork-point message was visible only
+    // in its pre-patch form on the new branch — id and sequence undefined —
+    // because MessageStore.add() does append-then-editStateItem, and
+    // forking at the original append's sequence captured the pre-patch
+    // state. Fix #2 stores the EDIT's sequence as the canonical
+    // commit-sequence, so a fork at messageId.sequence now lands at the
+    // edit record and the patched payload is inherited intact.
     for (let i = 0; i < 5; i++) {
       const text = onBranch[i]?.content?.[0];
       assert.ok(
         text && text.type === 'text' && text.text === `m${i}`,
         `forked branch message[${i}] should be "m${i}", got ${JSON.stringify(text)}`,
       );
+      assert.ok(
+        onBranch[i].id !== undefined && onBranch[i].id !== null,
+        `forked branch message[${i}].id must be defined (was the chained-branching bug), got ${onBranch[i].id}`,
+      );
+      assert.ok(
+        typeof onBranch[i].sequence === 'number' && Number.isFinite(onBranch[i].sequence),
+        `forked branch message[${i}].sequence must be a finite number, got ${onBranch[i].sequence}`,
+      );
     }
+    // The most specific check: the fork-point message on the new branch
+    // must equal the fork-point message on main (same id).
+    assert.equal(
+      onBranch[onBranch.length - 1].id,
+      ids[4],
+      'fork-point message on the new branch must have the same id as on main',
+    );
+
+    manager.close();
+  });
+
+  it('chained branching at the fork-point message preserves full message state', async () => {
+    // The bonus chained-branching bug: pre-fix, the FORK-POINT message
+    // on a new branch had id and sequence = undefined, because the
+    // append-then-patch dance left its patched payload at a chronicle
+    // sequence one PAST the fork-point. Anyone trying to branchAt the
+    // fork-point message on a forked branch would hit
+    // `idToIndex.get(undefined)` returning nothing → "Message not found".
+    // This test catches that by chaining two forks where the second
+    // forks AT the prior fork's fork-point message.
+    const strategy = new AutobiographicalStrategy({ targetChunkTokens: 300 });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const ids: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const id = manager.addMessage('user', textBlock(`m${i}`));
+      ids.push(id);
+    }
+
+    // Fork 1: at message index 4 (sees first 5 messages)
+    const fork1 = manager.branchAt(ids[4], 'chained-fork-1');
+    await manager.switchBranch(fork1);
+    const { messages: onFork1 } = manager.queryMessages({});
+    assert.equal(onFork1.length, 5);
+
+    // The fork-point message on fork1 must have full id/sequence — that's
+    // the precondition for branchAt to work from it.
+    const forkPointMsg = onFork1[onFork1.length - 1];
+    assert.ok(
+      forkPointMsg.id !== undefined && forkPointMsg.id !== null,
+      'fork-point message on a forked branch must have a defined id (was the chained-branching bug)',
+    );
+    assert.ok(
+      typeof forkPointMsg.sequence === 'number' && Number.isFinite(forkPointMsg.sequence),
+      'fork-point message on a forked branch must have a finite sequence',
+    );
+
+    // Fork 2: from fork1, AT the fork-point message of fork1.
+    // Pre-fix this throws "Message not found: undefined" because
+    // forkPointMsg.id is undefined on fork1.
+    const fork2 = manager.branchAt(forkPointMsg.id, 'chained-fork-2');
+    await manager.switchBranch(fork2);
+    const { messages: onFork2 } = manager.queryMessages({});
+    assert.equal(
+      onFork2.length,
+      5,
+      'fork2 forked at fork1.fork-point should see the same 5 messages as fork1',
+    );
 
     manager.close();
   });

--- a/test/message-store-sequence.test.ts
+++ b/test/message-store-sequence.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Regression test for the message-store sequence-vs-index bug.
+ *
+ * Before this fix, `MessageStore.get(id).sequence` returned the message's
+ * SLOT INDEX (its position in the message-store append-log) rather than the
+ * CHRONICLE RECORD SEQUENCE at which it was appended. Those two numbers
+ * diverge whenever any non-message record is appended between messages —
+ * which the autobio strategy does heavily, with `state_update` records for
+ * summary appends, mergeQueue snapshots, counter increments, etc. The
+ * typical ratio is ~1:2 (slot index : chronicle seq).
+ *
+ * `ContextManager.branchAt(messageId)` then passed `message.sequence` to
+ * `chronicle.createBranchAt(name, from, atSequence)`, which expects the
+ * chronicle sequence. Result: forks landed at chronicle sequence equal to
+ * the slot index — silently dropping every chronicle record between the
+ * intended fork point and the actual one. For an 800-message conversation
+ * this could fork ~400 messages back instead of one turn back.
+ *
+ * The fix returns `internal.sequence` (which is correctly populated from
+ * `record.sequence` at append time). These tests pin the contract so a
+ * future refactor can't reintroduce the "use index as sequence for now"
+ * shortcut.
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-message-store-sequence';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+function textBlock(text: string): ContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+describe('MessageStore — sequence semantics', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('returned sequence equals the chronicle record sequence (not the slot index)', async () => {
+    // Use the autobiographical strategy so its background state appends
+    // (counter, summaries, etc.) interleave with message appends — that's
+    // what makes slot-index and chronicle-sequence diverge.
+    const strategy = new AutobiographicalStrategy({ targetChunkTokens: 300 });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      const id = manager.addMessage('user', textBlock(`m${i}`));
+      ids.push(id);
+    }
+
+    // Walk the store: each successive message must have a STRICTLY GREATER
+    // chronicle sequence than the previous, AND the sequence must not equal
+    // the slot index (which is what the old code returned). The "not equal"
+    // half is the actual regression assertion.
+    const { messages } = manager.queryMessages({});
+    assert.equal(messages.length, 5);
+
+    let prevSeq = -1;
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i];
+      assert.ok(
+        typeof m.sequence === 'number' && Number.isFinite(m.sequence),
+        `message[${i}].sequence must be a finite number`,
+      );
+      assert.ok(
+        m.sequence > prevSeq,
+        `message[${i}].sequence (${m.sequence}) must be > previous (${prevSeq})`,
+      );
+      assert.notEqual(
+        m.sequence,
+        i,
+        `message[${i}].sequence (${m.sequence}) must not equal its slot index (${i}) — ` +
+          'that was the bug. Chronicle sequences are dense across all record types, not just messages.',
+      );
+      prevSeq = m.sequence;
+    }
+
+    // Belt-and-suspenders: also confirm get() agrees with query()'s view.
+    const last = manager.getMessage(ids[ids.length - 1]);
+    assert.ok(last, 'get(lastId) must return the message');
+    assert.equal(
+      last!.sequence,
+      messages[messages.length - 1].sequence,
+      'get() and query() must report the same sequence for the same message',
+    );
+
+    manager.close();
+  });
+
+  it('branchAt forks at the chronicle sequence — branch sees N messages, not slot-index-many', async () => {
+    // The end-to-end shape of the original bug. If sequence-vs-index is
+    // wrong, branchAt(messages[N-1].id) creates a fork at chronicle seq
+    // == (N-1), which lands far earlier than intended and the new branch
+    // sees only ~half the messages.
+    const strategy = new AutobiographicalStrategy({ targetChunkTokens: 300 });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+    });
+
+    const ids: string[] = [];
+    for (let i = 0; i < 6; i++) {
+      const id = manager.addMessage('user', textBlock(`m${i}`));
+      ids.push(id);
+    }
+
+    // Fork at the 5th message (index 4). The new branch must see exactly
+    // the first 5 messages — anything fewer means the fork landed at
+    // a too-early chronicle sequence (the bug).
+    const newBranch = manager.branchAt(ids[4]);
+    await manager.switchBranch(newBranch);
+
+    const { messages: onBranch } = manager.queryMessages({});
+    assert.equal(
+      onBranch.length,
+      5,
+      `forked branch must see exactly 5 messages, got ${onBranch.length}. ` +
+        'A smaller count means branchAt forked at the slot index instead of the chronicle sequence.',
+    );
+    // Verify the contents are the first 5 messages, in order. (We don't
+    // assert `onBranch[N-1].id === ids[4]` because of a separate bug:
+    // MessageStore.add() appends a partial record then patches in id/seq
+    // via a follow-up editStateItem, so the fork-point message's id/seq
+    // are inherited pre-patch on the new branch. Tracked as a follow-up;
+    // doesn't affect this test's invariant — the count is the part that
+    // matters for the original /undo regression.)
+    for (let i = 0; i < 5; i++) {
+      const text = onBranch[i]?.content?.[0];
+      assert.ok(
+        text && text.type === 'text' && text.text === `m${i}`,
+        `forked branch message[${i}] should be "m${i}", got ${JSON.stringify(text)}`,
+      );
+    }
+
+    manager.close();
+  });
+});


### PR DESCRIPTION
## Summary

Two related fixes in `MessageStore`/`ContextManager.branchAt`. Both were silently corrupting time-travel operations (`/undo`, `/restore`, `/checkout`, any `branchAt` call) on autobio-backed agents.

### Fix 1 (commit 54d4ecc): `.sequence` was the slot index, not the chronicle sequence

`MessageStore.internalToStored` substituted the message's slot index for the chronicle record sequence:

```typescript
sequence: index, // Use index as sequence for now
```

`ContextManager.branchAt` forwards `message.sequence` to `chronicle.createBranchAt(name, from, atSequence)`, which expects a real chronicle sequence. With the autobio strategy interleaving state-update records (~1:2 ratio of slot-index to chronicle-seq), `/undo` on an 800-message conversation forks ~400 messages back instead of one turn back. The session that surfaced this had a 867-entry messages slot on `main`, `/undo` created a branch with `branchPoint=865` (chronicle seq, but interpreted from slot index 865), and the new branch saw 427 messages.

Fix: return `internal.sequence`, which is correctly populated from `record.sequence` at append time (line 131).

### Fix 2 (commit 540b00d): fork-point message lost its id/sequence on the new branch

After fix 1, `branchAt` was still landing one seq too early. `MessageStore.append()` does append-then-`editStateItem` (the patch carries id/sequence, since those are only known after the append returns). The patch creates a separate chronicle record at `record.sequence + 1`. Forking at the original append's sequence captured the PRE-patch state — fork-point message had id and sequence undefined.

Chained scenario (the failure mode): after one `/undo`, calling `/undo` again would try to `branchAt` a message whose id was undefined → `idToIndex.get(undefined)` returns nothing → `"Message not found: undefined"` thrown. Or worse: it could resolve some other message and silently fork at the wrong place.

Fix: store the edit record's sequence (= `record.sequence + 1`, since no other chronicle write happens between the append and the edit inside this function) as the canonical "commit sequence." `branchAt` then forks at the edit's seq, so the patched payload is inherited intact on the new branch.

The `+1` invariant is comment-documented; future refactors that insert another write between append and edit need to update it.

## Tests

New `test/message-store-sequence.test.ts`:

1. **`.sequence` is the chronicle sequence, not the slot index.** Asserts monotonicity, finiteness, and `message.sequence !== index`.
2. **`branchAt` lands at the right place.** End-to-end: add 6 messages, fork at the 5th, assert the new branch sees exactly 5 messages with their full id/sequence on the fork-point.
3. **Chained branching at the fork-point message.** Fork once at message[4], then fork again from the new branch AT its fork-point message. Pre-fix this throws "Message not found: undefined".

`npm test`: **117/117** (was 114 prior to this PR + 3 new tests).

## Audit

Only one downstream consumer of `StoredMessage.sequence` outside `message-store.ts`: `ContextManager.branchAt` at line 330. The other call site reading `record.sequence` (line 139, building the in-memory `StoredMessage` returned to callers) is updated to use the same commit sequence so what callers see matches what's stored.

## Why this matters

These bugs have been silently corrupting every `branchAt` operation since the placeholder comment ("Use index as sequence for now") was written. Anyone using `/undo` / `/restore` / `/checkout` / `/branch` against an autobio-backed agent has been getting wrong fork points and, when chaining, broken state. The user's session today had clear data showing `/undo` rolling back ~440 messages instead of 1; chained `/undo` would have failed outright (no longer reproducible since the snapshot was taken pre-chain — but the regression test now pins this case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)