### PR TITLE
feat(autobio): add getProgressSnapshot for external observability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/context-manager",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Context management layer for LLM-based agents using Chronicle and Membrane",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export { BlobManager } from './blob-manager.js';
 
 // Strategies
 export { PassthroughStrategy } from './strategies/passthrough.js';
-export { AutobiographicalStrategy } from './strategies/autobiographical.js';
+export { AutobiographicalStrategy, type AutobiographicalProgressSnapshot } from './strategies/autobiographical.js';
 export { KnowledgeStrategy } from './strategies/knowledge.js';
 
 // Types

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -60,6 +60,27 @@ export interface Chunk {
 }
 
 /**
+ * Point-in-time snapshot of compression progress, returned from
+ * `AutobiographicalStrategy.getProgressSnapshot()`. External observers
+ * (warmup scripts, dashboards) use this to track convergence without
+ * reaching into the strategy's protected fields.
+ */
+export interface AutobiographicalProgressSnapshot {
+  /** All chunks the strategy is tracking, compressed or not. */
+  totalChunks: number;
+  /** Chunks that already have an L1 summary. */
+  chunksCompressed: number;
+  /** Chunks queued for L1 compression. */
+  l1QueueLength: number;
+  /** Pending L1→L2 and L2→L3 merges. */
+  mergeQueueLength: number;
+  /** Stored summary counts per level (1 = raw L1, 2 = L1→L2 merge, 3 = L2→L3 merge). */
+  summaryCounts: { l1: number; l2: number; l3: number };
+  /** True if a compression or merge LLM call is currently in flight. */
+  pending: boolean;
+}
+
+/**
  * Autobiographical chunking strategy.
  * Compresses old conversation chunks into summaries in the model's own words.
  * Recent context stays untouched.
@@ -578,6 +599,31 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         this.pendingCompression = null;
       }
     }
+  }
+
+  /**
+   * Snapshot of compression progress. Intended for external observers
+   * (warmup scripts, dashboards) that need to track convergence without
+   * reaching into protected fields. Values are point-in-time copies; mutating
+   * them does not affect strategy state.
+   */
+  getProgressSnapshot(): AutobiographicalProgressSnapshot {
+    let chunksCompressed = 0;
+    for (const c of this.chunks) if (c.compressed) chunksCompressed++;
+    let l1 = 0, l2 = 0, l3 = 0;
+    for (const s of this.summaries) {
+      if (s.level === 1) l1++;
+      else if (s.level === 2) l2++;
+      else if (s.level === 3) l3++;
+    }
+    return {
+      totalChunks: this.chunks.length,
+      chunksCompressed,
+      l1QueueLength: this.compressionQueue.length,
+      mergeQueueLength: this.mergeQueue.length,
+      summaryCounts: { l1, l2, l3 },
+      pending: this.pendingCompression !== null,
+    };
   }
 
   select(

--- a/src/strategies/index.ts
+++ b/src/strategies/index.ts
@@ -1,2 +1,2 @@
 export { PassthroughStrategy } from './passthrough.js';
-export { AutobiographicalStrategy } from './autobiographical.js';
+export { AutobiographicalStrategy, type AutobiographicalProgressSnapshot } from './autobiographical.js';


### PR DESCRIPTION
## Summary

- Adds a public \`getProgressSnapshot()\` method to \`AutobiographicalStrategy\` that returns a point-in-time view of compression progress (chunk totals, queue lengths per phase, summary counts per level, in-flight flag).
- Bumps version to 0.4.1.

## Motivation

External observers — warmup scripts, dashboards, anything that needs to track autobio's convergence — previously had to subclass and reach into protected fields (\`compressionQueue\`, \`mergeQueue\`, \`pendingCompression\`, etc.). That's brittle to any internal rename. This method is the stable boundary.

First consumer: \`connectome-host\`'s \`scripts/warmup-session.ts\`, which drives autobio to convergence after bulk-importing claude.ai exports.

## Test plan

- [ ] CI passes (build + existing tests)
- [ ] Downstream test in connectome-host (\`test/autobio-progress-snapshot.test.ts\`) asserts the returned shape; will fail loudly if any field gets renamed