### PR TITLE
Adaptive resolution + live-image policy

### DIFF
--- a/src/context-log.ts
+++ b/src/context-log.ts
@@ -286,7 +286,7 @@ export class ContextLog {
         }
         return block.content.reduce((sum, b) => sum + this.estimateBlockTokens(b), 0);
       case 'image':
-        return block.tokenEstimate ?? 1000;
+        return block.tokenEstimate ?? 1600; // ~1568px image ≈ 1600 tokens (Anthropic)
       case 'document':
       case 'audio':
       case 'video':

--- a/src/message-store.ts
+++ b/src/message-store.ts
@@ -411,7 +411,7 @@ export class MessageStore {
         }
         return 0;
       case 'image':
-        return block.tokenEstimate ?? 1000; // Default estimate for images
+        return block.tokenEstimate ?? 1600; // ~1568px image ≈ 1600 tokens (Anthropic)
       case 'document':
       case 'audio':
       case 'video':

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1056,12 +1056,19 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   ): ContextEntry[] {
     this.rebuildChunks(store);
 
+    let entries: ContextEntry[];
     if (this.config.adaptiveResolution) {
-      return this.selectAdaptive(store, budget);
+      entries = this.selectAdaptive(store, budget);
+    } else {
+      entries = this.config.hierarchical
+        ? this.selectHierarchical(store, budget)
+        : this.selectLegacy(store, log, budget);
     }
-    return this.config.hierarchical
-      ? this.selectHierarchical(store, budget)
-      : this.selectLegacy(store, log, budget);
+    // Single post-pass across every compile path: strip stale images to text
+    // placeholders so the live image payload stays bounded regardless of how
+    // far back the verbatim text window reaches.
+    this.applyImageStripping(entries, store);
+    return entries;
   }
 
   /**
@@ -3333,6 +3340,69 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
   protected chunkKey(chunk: Chunk): string {
     return chunk.messages.map((m) => m.id).join(':');
+  }
+
+  /** True if any content block is a live image. */
+  protected hasImageBlock(content: ContentBlock[]): boolean {
+    return content.some((b) => b.type === 'image');
+  }
+
+  /** Message index marking the image-strip depth boundary: walks newest→oldest
+   *  summing the same per-message estimate as getRecentWindowStart, and returns
+   *  the index of the first message still within `depthTokens`. Messages before
+   *  this index have their images stripped to placeholders. */
+  protected getImageStripStart(store: MessageStoreView, depthTokens: number): number {
+    const messages = store.getAll();
+    let tokens = 0;
+    for (let i = messages.length - 1; i >= 0; i--) {
+      tokens += store.estimateTokens(messages[i]);
+      if (tokens > depthTokens) return i + 1;
+    }
+    return 0;
+  }
+
+  /** Post-pass over compiled entries: replace image blocks with a text
+   *  placeholder once they fall outside the live-image window — either deeper
+   *  than `imageStripDepthTokens` from the newest message, or beyond the
+   *  `maxLiveImages` most-recent images (counted newest-first). Summaries are
+   *  already text, so they're naturally unaffected. The adjacent
+   *  "[image attachment: <name>]" text added at ingest preserves the filename,
+   *  so the placeholder itself stays terse. Reduces tokens, so it never pushes
+   *  a compiled context back over budget. */
+  protected applyImageStripping(entries: ContextEntry[], store: MessageStoreView): void {
+    const maxLive = this.config.maxLiveImages ?? 0;             // 0 = unlimited count
+    const depthTokens = this.config.imageStripDepthTokens ?? 0; // 0 = no depth strip
+    if (maxLive === 0 && depthTokens === 0) return;             // policy disabled
+
+    const messages = store.getAll();
+    const posById = new Map<string, number>();
+    for (let i = 0; i < messages.length; i++) posById.set(messages[i].id, i);
+    const stripStart = depthTokens > 0 ? this.getImageStripStart(store, depthTokens) : 0;
+
+    // Image-bearing entries, newest-first by source position. Entries with no
+    // resolvable source position sort last (pos -1) and never count as "live".
+    const ordered = entries
+      .map((entry, idx) => ({
+        idx,
+        pos: entry.sourceMessageId !== undefined ? posById.get(entry.sourceMessageId) ?? -1 : -1,
+      }))
+      .filter(({ idx }) => this.hasImageBlock(entries[idx].content))
+      .sort((a, b) => b.pos - a.pos);
+
+    let keptImages = 0;
+    for (const { idx, pos } of ordered) {
+      const entry = entries[idx];
+      const tooDeep = depthTokens > 0 && (pos < 0 || pos < stripStart);
+      entry.content = entry.content.map((block) => {
+        if (block.type !== 'image') return block;
+        const overCount = maxLive > 0 && keptImages >= maxLive;
+        if (tooDeep || overCount) {
+          return { type: 'text', text: '[image dropped from live context]' } as ContentBlock;
+        }
+        keptImages++;
+        return block;
+      });
+    }
   }
 
   protected getRecentWindowStart(store: MessageStoreView): number {

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -316,6 +316,19 @@ export interface AutobiographicalConfig {
    *  this limit have their text/tool_result content truncated. 0 = no limit. */
   maxMessageTokens: number;
 
+  // --- Live image policy ---
+
+  /** Maximum number of images kept "live" (sent as real image blocks) in the
+   *  compiled context. Counted newest-first across the whole window; images
+   *  beyond this many are replaced with a text placeholder. 0 = unlimited.
+   *  A hard ceiling for dense bursts that pack many images into the live window. */
+  maxLiveImages?: number;
+  /** Token depth from the newest message beyond which images are stripped to a
+   *  text placeholder, even though the surrounding text stays verbatim. Measured
+   *  the same way as recentWindowTokens (cumulative tokens walked from the tail).
+   *  Typically much shallower than recentWindowTokens. 0 = never strip by depth. */
+  imageStripDepthTokens?: number;
+
   // Legacy aliases (deprecated, use summary* instead)
   /** @deprecated Use summarySystemPrompt */
   diarySystemPrompt?: string;
@@ -599,6 +612,8 @@ Write naturally, as recollection of what you experienced.`,
   summaryContextLabel: 'What do you remember from earlier?',
   summaryParticipant: 'Claude',
   maxMessageTokens: 0,
+  maxLiveImages: 6,
+  imageStripDepthTokens: 30000,
   positionedRecallPairs: true,
   recallHeaderTemplate: '[Recall {id}]',
 };

--- a/test/image-stripping.test.ts
+++ b/test/image-stripping.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the live-image policy in AutobiographicalStrategy:
+ *
+ *   (1) maxLiveImages — a hard count ceiling. Only the N most-recent images
+ *       survive as real image blocks; older ones become text placeholders.
+ *   (2) imageStripDepthTokens — a depth cutoff. Images deeper than D tokens
+ *       from the newest message are stripped even though the surrounding text
+ *       stays verbatim (so text horizon >> image horizon).
+ *
+ * Stripped images are replaced by "[image dropped from live context]".
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-image-stripping';
+
+function cleanup() {
+  if (existsSync(TEST_STORE_PATH)) rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+}
+
+/** A message carrying one image plus a text label so we can locate it later. */
+function imageMessage(label: string, tokenEstimate = 1600): ContentBlock[] {
+  return [
+    { type: 'image', source: { type: 'base64', data: 'AAAA', mediaType: 'image/png' }, tokenEstimate } as ContentBlock,
+    { type: 'text', text: label },
+  ];
+}
+
+/** Find the compiled entry whose text contains `label`, and report whether it
+ *  still holds a real image block or was reduced to the placeholder. */
+function imageState(messages: { content: ContentBlock[] }[], label: string): 'image' | 'stripped' | 'missing' {
+  const entry = messages.find((m) =>
+    m.content.some((b) => b.type === 'text' && b.text.includes(label)),
+  );
+  if (!entry) return 'missing';
+  if (entry.content.some((b) => b.type === 'image')) return 'image';
+  if (entry.content.some((b) => b.type === 'text' && b.text.includes('image dropped from live context')))
+    return 'stripped';
+  return 'missing';
+}
+
+describe('Live image policy', () => {
+  before(() => cleanup());
+  after(() => cleanup());
+
+  it('keeps only the maxLiveImages most-recent images (count cap)', async () => {
+    cleanup();
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 1_000_000, // keep everything verbatim
+      hierarchical: true,
+      maxLiveImages: 2,
+      imageStripDepthTokens: 0, // disable depth strip — isolate the count cap
+    });
+    const manager = await ContextManager.open({ path: TEST_STORE_PATH, strategy });
+
+    for (let i = 1; i <= 4; i++) manager.addMessage('user', imageMessage(`img-0${i}`));
+
+    const compiled = await manager.compile({ maxTokens: 1_000_000, reserveForResponse: 0 });
+
+    // Newest two (img-03, img-04) keep their image; older two are stripped.
+    assert.equal(imageState(compiled.messages, 'img-04'), 'image', 'newest image kept');
+    assert.equal(imageState(compiled.messages, 'img-03'), 'image', '2nd-newest image kept');
+    assert.equal(imageState(compiled.messages, 'img-02'), 'stripped', '3rd-newest stripped by count cap');
+    assert.equal(imageState(compiled.messages, 'img-01'), 'stripped', 'oldest stripped by count cap');
+
+    manager.close();
+  });
+
+  it('strips images deeper than imageStripDepthTokens (depth cutoff)', async () => {
+    cleanup();
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 1_000_000, // text horizon stays huge
+      hierarchical: true,
+      maxLiveImages: 0, // unlimited count — isolate the depth cutoff
+      imageStripDepthTokens: 3500, // ~2 images (1600 each) fit within the window
+    });
+    const manager = await ContextManager.open({ path: TEST_STORE_PATH, strategy });
+
+    for (let i = 1; i <= 4; i++) manager.addMessage('user', imageMessage(`img-0${i}`));
+
+    const compiled = await manager.compile({ maxTokens: 1_000_000, reserveForResponse: 0 });
+
+    // Newest fits inside the depth window; the oldest is well beyond it.
+    assert.equal(imageState(compiled.messages, 'img-04'), 'image', 'newest image within depth window');
+    assert.equal(imageState(compiled.messages, 'img-01'), 'stripped', 'oldest image beyond depth window');
+
+    // But the text of the stripped message is still present verbatim (text
+    // horizon is independent of the image horizon).
+    const oldestText = compiled.messages.find((m) =>
+      m.content.some((b) => b.type === 'text' && b.text.includes('img-01')),
+    );
+    assert.ok(oldestText, 'oldest message text survives even though its image was stripped');
+
+    manager.close();
+  });
+
+  it('leaves images untouched when the policy is disabled', async () => {
+    cleanup();
+    const strategy = new AutobiographicalStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 1_000_000,
+      hierarchical: true,
+      maxLiveImages: 0,
+      imageStripDepthTokens: 0,
+    });
+    const manager = await ContextManager.open({ path: TEST_STORE_PATH, strategy });
+
+    for (let i = 1; i <= 3; i++) manager.addMessage('user', imageMessage(`img-0${i}`));
+
+    const compiled = await manager.compile({ maxTokens: 1_000_000, reserveForResponse: 0 });
+
+    for (const label of ['img-01', 'img-02', 'img-03']) {
+      assert.equal(imageState(compiled.messages, label), 'image', `${label} kept when policy disabled`);
+    }
+
+    manager.close();
+  });
+});


### PR DESCRIPTION
Integration PR for the `feat/adaptive-resolution` branch (21 commits ahead of `main`). The V1 scaffold landed earlier via #19, but the full feature plus subsequent work never reached `main` — this brings it all in.

## Adaptive resolution
- Picker + chunker + strategies scaffold; wired into `AutobiographicalStrategy` via the `adaptiveResolution` flag and the ingestion path.
- Recursive bottom-up pre-producer for unbounded L_n; `OverBudgetError` when the picker is exhausted over hard budget.
- Resolutions + locks persisted via chronicle state slots.
- Q+A recall pairs emitted as separate messages within bodyGroups; raw-shard merge across all emission paths.

## Compression quality
- KV-preserving compression prompt (per hermes-autobio spec); merge prompt shows one-level-deeper content + chronological prefix.
- Reading-mode instructions for sub-message chunks and bodyGroup-rooted merges (kills voice drift).
- Always include head window in compression; always-on JSONL logging of compression LLM calls.

## Live-image policy (new)
- `imageStripDepthTokens` (default 30000) — strip images deeper than this many tokens from the newest message to a placeholder, even though surrounding text stays verbatim out to `recentWindowTokens`.
- `maxLiveImages` (default 6) — hard ceiling on live images, newest-first.
- Single post-pass in `select()` covering all compile paths; per-image token estimate corrected 1000 → 1600.

## Tests
Adaptive integration coverage (branching, long-chronicle, doc+chat) + image-stripping (count cap, depth cutoff, disabled). Full suite: 117/120 pass (3 pre-existing failures unrelated to this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)