### PR TITLE
Consolidate: adaptive resolution as default + signed-thinking support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@animalabs/context-manager",
-  "version": "0.3.0",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@animalabs/context-manager",
-      "version": "0.3.0",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
-        "@animalabs/chronicle": "^0.1.0",
-        "@animalabs/membrane": "^0.5.40"
+        "@animalabs/chronicle": "^0.2.0",
+        "@animalabs/membrane": "^0.5.64"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -21,22 +21,22 @@
       }
     },
     "node_modules/@animalabs/chronicle": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.1.1.tgz",
-      "integrity": "sha512-/yeeUpIkRnPS7s+XbXzveKNBRqMFPWmknwe98vBtFOR1ovp+ENgF0HmfFPC4XDeqO4B3v8S+EZkWkiOw+kwJkQ==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.2.1.tgz",
+      "integrity": "sha512-rDFc069yfi7BQUusgsXBwBdqljUWLByXSYaTF40AP+tonBh0No3eF9VzKTSy1I8DYg/jAUHIKtVdKDGsVMVubw==",
       "license": "MIT",
       "optionalDependencies": {
-        "@animalabs/chronicle-darwin-arm64": "0.1.1",
-        "@animalabs/chronicle-darwin-x64": "0.1.1",
-        "@animalabs/chronicle-linux-arm64-gnu": "0.1.1",
-        "@animalabs/chronicle-linux-x64-gnu": "0.1.1",
-        "@animalabs/chronicle-win32-x64-msvc": "0.1.1"
+        "@animalabs/chronicle-darwin-arm64": "0.2.1",
+        "@animalabs/chronicle-darwin-x64": "0.2.1",
+        "@animalabs/chronicle-linux-arm64-gnu": "0.2.1",
+        "@animalabs/chronicle-linux-x64-gnu": "0.2.1",
+        "@animalabs/chronicle-win32-x64-msvc": "0.2.1"
       }
     },
     "node_modules/@animalabs/membrane": {
-      "version": "0.5.41",
-      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.41.tgz",
-      "integrity": "sha512-6mwXZK5GWWRFPADCmi7IgZdNuTTBzwRMkk/oDEphvWyimu5UIIVK/+0PfhI2/Qm9v8mfu4fUVXkUG6ajnTlDYw==",
+      "version": "0.5.64",
+      "resolved": "https://registry.npmjs.org/@animalabs/membrane/-/membrane-0.5.64.tgz",
+      "integrity": "sha512-lz6BwjIGp5W8GCOvMTX6kXYgd258FH7xIra/D6rDvtO5dubtSDuf6eKueEpKRDF6Go8175bnrX6JrXtA2XvP4g==",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "license": "MIT",
   "dependencies": {
     "@animalabs/chronicle": "^0.2.0",
-    "@animalabs/membrane": "^0.5.40"
+    "@animalabs/membrane": "^0.5.64"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/context-log.ts
+++ b/src/context-log.ts
@@ -276,7 +276,12 @@ export class ContextLog {
       case 'text':
         return this.tokenEstimator(block.text);
       case 'thinking':
-        return this.tokenEstimator(block.thinking);
+        // Signature-only blocks (display:'omitted') carry empty thinking text
+        return this.tokenEstimator(block.thinking ?? '');
+      case 'redacted_thinking':
+        // Encrypted reasoning payload, round-tripped verbatim — rough
+        // estimate from the data length so budgeting isn't blind to it.
+        return this.tokenEstimator((block as { data?: string }).data ?? '');
       case 'tool_use':
         return this.tokenEstimator(JSON.stringify(block.input)) + 20;
       case 'tool_result':

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1134,17 +1134,13 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   ): ContextEntry[] {
     this.rebuildChunks(store);
 
-    let entries: ContextEntry[];
+    // Image stripping runs inside each select path (before stats commit / cache
+    // markers), so the returned entries are already bounded — see
+    // applyImageStripping.
     if (this.config.adaptiveResolution) {
-      entries = this.selectAdaptive(store, budget);
-    } else {
-      entries = this.selectHierarchical(store, budget);
+      return this.selectAdaptive(store, budget);
     }
-    // Single post-pass across every compile path: strip stale images to text
-    // placeholders so the live image payload stays bounded regardless of how
-    // far back the verbatim text window reaches.
-    this.applyImageStripping(entries, store);
-    return entries;
+    return this.selectHierarchical(store, budget);
   }
 
   /**
@@ -2582,6 +2578,9 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
     this.pruneToolEntries(merged);
     this.trimOrphanedToolUse(merged);
+    // Strip stale images BEFORE placing markers and committing stats, so both
+    // describe the post-strip context the agent actually receives.
+    this.applyImageStripping(merged, store);
     // Place ≤4 cache breakpoints across the FINAL ordered entries so the
     // provider can reuse the stable folded prefix — not just the head. With a
     // single head marker the cache hit is ~2%; well-placed breakpoints take the
@@ -3090,6 +3089,9 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
     this.trimOrphanedToolUse(entries);
     this.pruneToolEntries(entries);
+    // Strip stale images before committing stats so RenderStats.total reflects
+    // the post-strip context (this path places no cache markers).
+    this.applyImageStripping(entries, store);
     this.rsEnd();
     return entries;
   }
@@ -3559,6 +3561,9 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     return 0;
   }
 
+  /** Text substituted for an image block once it leaves the live-image window. */
+  private static readonly IMAGE_PLACEHOLDER = '[image dropped from live context]';
+
   /** Post-pass over compiled entries: replace image blocks with a text
    *  placeholder once they fall outside the live-image window — either deeper
    *  than `imageStripDepthTokens` from the newest message, or beyond the
@@ -3566,7 +3571,13 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    *  already text, so they're naturally unaffected. The adjacent
    *  "[image attachment: <name>]" text added at ingest preserves the filename,
    *  so the placeholder itself stays terse. Reduces tokens, so it never pushes
-   *  a compiled context back over budget. */
+   *  a compiled context back over budget.
+   *
+   *  Runs INSIDE each select path, *before* `rsEnd()` and `placeCacheMarkers`,
+   *  so the committed render stats (and the cache breakpoints) describe the
+   *  post-strip context. As it strips, it decrements the matching raw bucket of
+   *  the in-progress render stats by the reclaimed tokens, keeping
+   *  `RenderStats.total` equal to the real rendered size. */
   protected applyImageStripping(entries: ContextEntry[], store: MessageStoreView): void {
     const maxLive = this.config.maxLiveImages ?? 0;             // 0 = unlimited count
     const depthTokens = this.config.imageStripDepthTokens ?? 0; // 0 = no depth strip
@@ -3576,6 +3587,19 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const posById = new Map<string, number>();
     for (let i = 0; i < messages.length; i++) posById.set(messages[i].id, i);
     const stripStart = depthTokens > 0 ? this.getImageStripStart(store, depthTokens) : 0;
+
+    // Same region windows select() bucketed by, so a stripped image's reclaimed
+    // tokens come back out of the bucket it was originally tallied into.
+    const headStart = this.getHeadWindowStartIndex(store);
+    const headEnd = this.getHeadWindowEnd(store);
+    const recentStart = Math.max(this.getRecentWindowStart(store), headEnd);
+    const bucketAt = (pos: number): 'head' | 'tail' | 'middleRaw' => {
+      if (pos < 0) return 'middleRaw'; // no resolvable region — keep total == Σbuckets
+      if (pos >= headStart && pos < headEnd) return 'head';
+      if (pos >= recentStart) return 'tail';
+      return 'middleRaw';
+    };
+    const placeholderTokens = Math.ceil(AutobiographicalStrategy.IMAGE_PLACEHOLDER.length / 4);
 
     // Image-bearing entries, newest-first by source position. Entries with no
     // resolvable source position sort last (pos -1) and never count as "live".
@@ -3591,11 +3615,18 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     for (const { idx, pos } of ordered) {
       const entry = entries[idx];
       const tooDeep = depthTokens > 0 && (pos < 0 || pos < stripStart);
+      const bucket = bucketAt(pos);
       entry.content = entry.content.map((block) => {
         if (block.type !== 'image') return block;
         const overCount = maxLive > 0 && keptImages >= maxLive;
         if (tooDeep || overCount) {
-          return { type: 'text', text: '[image dropped from live context]' } as ContentBlock;
+          // The renderer estimates an image at `tokenEstimate ?? 1600` (see
+          // message-store/context-log). Hand that back to the bucket, less the
+          // placeholder text that replaces it, so the stats match the output.
+          const reclaimed =
+            ((block as { tokenEstimate?: number }).tokenEstimate ?? 1600) - placeholderTokens;
+          if (this._rs && reclaimed > 0) this._rs[bucket].tokens -= reclaimed;
+          return { type: 'text', text: AutobiographicalStrategy.IMAGE_PLACEHOLDER } as ContentBlock;
         }
         keptImages++;
         return block;

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -17,6 +17,7 @@ import type {
   ProtectedRange,
   SearchQuery,
   SearchResult,
+  RenderStats,
 } from '../types/index.js';
 import { DEFAULT_AUTOBIOGRAPHICAL_CONFIG } from '../types/index.js';
 import { getSummaryParentId } from '../types/strategy.js';
@@ -1173,16 +1174,89 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * Useful for TUI / dashboards. The token sums use the strategy's own
    * token estimates (which match what `select()` uses for budget math).
    */
-  getRenderStats(store: MessageStoreView): {
-    head: { messages: number; tokens: number };
-    tail: { messages: number; tokens: number };
-    summaries: {
-      l1: { count: number; tokens: number };
-      l2: { count: number; tokens: number };
-      l3: { count: number; tokens: number };
+  // ===========================================================================
+  // Render-stats instrumentation — inspect, don't reconstruct.
+  //
+  // selectAdaptive/selectHierarchical tally each entry into `_rs` AS THEY EMIT
+  // it (raw head/tail, raw middle the picker kept verbatim, and recall pairs
+  // bucketed by the ancestor summary's level), using the same token numbers the
+  // renderer uses for budget math. `getRenderStats()` returns that committed
+  // snapshot, so it reflects what the last compile actually rendered rather than
+  // re-deriving the full pyramid (which, under adaptive resolution, bears little
+  // resemblance to the folded output).
+  // ===========================================================================
+  private _rs: RenderStats | null = null;
+  private _lastRenderStats: RenderStats | null = null;
+
+  /** Begin a render-stats accumulation for one select() pass. */
+  protected rsBegin(): void {
+    this._rs = {
+      head: { messages: 0, tokens: 0 },
+      tail: { messages: 0, tokens: 0 },
+      middleRaw: { messages: 0, tokens: 0 },
+      summaries: {
+        l1: { count: 0, tokens: 0 },
+        l2: { count: 0, tokens: 0 },
+        l3: { count: 0, tokens: 0 },
+      },
+      pending: { chunks: 0, merges: 0 },
+      total: { messages: 0, tokens: 0 },
     };
-    pending: { chunks: number; merges: number };
-  } {
+  }
+
+  /** Tally one (or `count`) raw message(s) into a raw bucket. */
+  protected rsRaw(bucket: 'head' | 'tail' | 'middleRaw', tokens: number, count = 1): void {
+    const r = this._rs;
+    if (!r) return;
+    r[bucket].messages += count;
+    r[bucket].tokens += tokens;
+  }
+
+  /** Tally one emitted recall pair under its ancestor's level (>=3 folds into l3). */
+  protected rsSummary(level: number, tokens: number): void {
+    const r = this._rs;
+    if (!r) return;
+    const k: 'l1' | 'l2' | 'l3' = level <= 1 ? 'l1' : level === 2 ? 'l2' : 'l3';
+    r.summaries[k].count += 1;
+    r.summaries[k].tokens += tokens;
+  }
+
+  /** Commit the accumulated stats as the last-render snapshot. */
+  protected rsEnd(): void {
+    const r = this._rs;
+    if (!r) return;
+    r.pending = {
+      chunks: this.chunks.filter(c => !c.compressed).length,
+      merges: this.mergeQueue.length,
+    };
+    const s = r.summaries;
+    const summaryMsgs = (s.l1.count + s.l2.count + s.l3.count) * 2; // Q/A pair each
+    r.total = {
+      messages: r.head.messages + r.tail.messages + r.middleRaw.messages + summaryMsgs,
+      tokens:
+        r.head.tokens + r.tail.tokens + r.middleRaw.tokens +
+        s.l1.tokens + s.l2.tokens + s.l3.tokens,
+    };
+    this._lastRenderStats = r;
+    this._rs = null;
+  }
+
+  /**
+   * Stats describing the LAST rendered context. Returns the inspected snapshot
+   * captured during the most recent `select()`. Before any compile has run (no
+   * snapshot yet), falls back to a reconstructed pyramid view so callers still
+   * get a non-null shape.
+   */
+  getRenderStats(store: MessageStoreView): RenderStats {
+    return this._lastRenderStats ?? this.reconstructRenderStats(store);
+  }
+
+  /**
+   * Pre-render fallback: re-derive head/tail windows + the full live pyramid.
+   * NOTE: this is the old "reconstruct" behavior and does NOT reflect adaptive
+   * folding — used only until the first compile populates the inspected stats.
+   */
+  protected reconstructRenderStats(store: MessageStoreView): RenderStats {
     const messages = store.getAll();
     const headStart = this.getHeadWindowStartIndex(store);
     const headEnd = this.getHeadWindowEnd(store);
@@ -1199,17 +1273,27 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const sumLevelTokens = (level: SummaryLevel): number =>
       live(level).reduce((acc, s) => acc + s.tokens, 0);
 
+    const head = { messages: headMsgs.length, tokens: sumTokens(headMsgs) };
+    const tail = { messages: tailMsgs.length, tokens: sumTokens(tailMsgs) };
+    const summaries = {
+      l1: { count: live(1).length, tokens: sumLevelTokens(1) },
+      l2: { count: live(2).length, tokens: sumLevelTokens(2) },
+      l3: { count: live(3).length, tokens: sumLevelTokens(3) },
+    };
     return {
-      head: { messages: headMsgs.length, tokens: sumTokens(headMsgs) },
-      tail: { messages: tailMsgs.length, tokens: sumTokens(tailMsgs) },
-      summaries: {
-        l1: { count: live(1).length, tokens: sumLevelTokens(1) },
-        l2: { count: live(2).length, tokens: sumLevelTokens(2) },
-        l3: { count: live(3).length, tokens: sumLevelTokens(3) },
-      },
+      head,
+      tail,
+      middleRaw: { messages: 0, tokens: 0 },
+      summaries,
       pending: {
         chunks: this.chunks.filter(c => !c.compressed).length,
         merges: this.mergeQueue.length,
+      },
+      total: {
+        messages: head.messages + tail.messages
+          + (summaries.l1.count + summaries.l2.count + summaries.l3.count) * 2,
+        tokens: head.tokens + tail.tokens
+          + summaries.l1.tokens + summaries.l2.tokens + summaries.l3.tokens,
       },
     };
   }
@@ -1233,8 +1317,8 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     msgCap: number,
     maxTokens: number,
     totalTokensBefore: number,
-  ): void {
-    if (recentStart >= messages.length) return;
+  ): { messages: number; tokens: number } {
+    if (recentStart >= messages.length) return { messages: 0, tokens: 0 };
 
     const accepted: number[] = [];
     let acceptedTokens = 0;
@@ -1258,9 +1342,13 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       accepted.shift();
     }
 
+    let emittedTokens = 0;
     for (const i of accepted) {
       const msg = messages[i];
       const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
+      const tokens = msgCap > 0
+        ? Math.min(store.estimateTokens(msg), msgCap + 50)
+        : store.estimateTokens(msg);
       entries.push({
         index: entries.length,
         sourceMessageId: msg.id,
@@ -1268,7 +1356,9 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         participant: msg.participant,
         content,
       });
+      emittedTokens += tokens;
     }
+    return { messages: accepted.length, tokens: emittedTokens };
   }
 
   // ============================================================================
@@ -1516,6 +1606,10 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
     try {
       const response = await ctx.membrane.complete(request, { formatter: this.nativeFormatter });
+      // Text-only on purpose: this is the SUMMARIZER's one-shot response —
+      // its thinking/redacted_thinking blocks are scratch work, not part of
+      // the agent's history, and signed thinking is never valid inside a
+      // rewritten summary anyway.
       const summaryText = response.content
         .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
         .map(b => b.text)
@@ -1973,6 +2067,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
     try {
       const response = await ctx.membrane.complete(request, { formatter: this.nativeFormatter });
+      // Text-only on purpose: summarizer scratch thinking is not agent history
       const mergedText = response.content
         .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
         .map(b => b.text)
@@ -2057,6 +2152,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * See `docs/adaptive-resolution-design.md` §3, §5.
    */
   protected selectAdaptive(store: MessageStoreView, budget: TokenBudget): ContextEntry[] {
+    this.rsBegin();
     const entries: ContextEntry[] = [];
     const maxTokens = budget.maxTokens - budget.reserveForResponse;
     const messages = store.getAll();
@@ -2090,6 +2186,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       totalTokens += tokens;
       headMessageIds.add(msg.id);
       headTokens += tokens;
+      this.rsRaw('head', tokens);
     }
     // (Cache breakpoints are placed in one pass over the FINAL ordered entries
     // below — see placeCacheMarkers — capturing the stable folded prefix, not
@@ -2335,6 +2432,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
               content,
             });
             totalTokens += tokens;
+            this.rsRaw('middleRaw', tokens);
           } else {
             // summary run — emit Q+A pair, dedup at the strategy level
             const ancestor = currentRun.ancestor;
@@ -2361,6 +2459,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
               entries.push(questionEntry);
               entries.push(answerEntry);
               totalTokens += pairTokens;
+              this.rsSummary(ancestor.level, pairTokens);
             }
           }
           currentRun = null;
@@ -2421,6 +2520,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
           content,
         });
         totalTokens += tokens;
+        this.rsRaw('middleRaw', tokens);
         i++;
       } else {
         const ancestor = this.findAncestorAt(msg.id, resolution, chunksByMessageId, summariesById);
@@ -2436,6 +2536,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
             content,
           });
           totalTokens += tokens;
+          this.rsRaw('middleRaw', tokens);
           i++;
           continue;
         }
@@ -2462,12 +2563,14 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         entries.push(questionEntry);
         entries.push(answerEntry);
         totalTokens += pairTokens;
+        this.rsSummary(ancestor.level, pairTokens);
         i++;
       }
     }
 
     // ----- 6. Emit tail entries newest-first eviction (matches existing behavior) -----
-    this.emitRecentNewestFirst(entries, store, messages, effectiveRecentStart, msgCap, maxTokens, totalTokens);
+    const tailStats = this.emitRecentNewestFirst(entries, store, messages, effectiveRecentStart, msgCap, maxTokens, totalTokens);
+    this.rsRaw('tail', tailStats.tokens, tailStats.messages);
 
     // ----- 7. Post-process: merge consecutive raw entries from the same bodyGroup -----
     // Both head and tail emission paths emit shards as separate ContextEntries.
@@ -2485,6 +2588,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     // real strategy to ~50% (docs/kv-stable-context-control.md — marker
     // placement is the dominant KV lever).
     this.placeCacheMarkers(merged, headMessageIds, tailMessageIds);
+    this.rsEnd();
     return merged;
   }
 
@@ -2716,6 +2820,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * Matches moltbot's budget waterfall: L3 → L2 → L1 with unused budget flowing down.
    */
   protected selectHierarchical(store: MessageStoreView, budget: TokenBudget): ContextEntry[] {
+    this.rsBegin();
     const entries: ContextEntry[] = [];
     const maxTokens = budget.maxTokens - budget.reserveForResponse;
     const messages = store.getAll();
@@ -2740,6 +2845,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         content,
       });
       totalTokens += tokens;
+      this.rsRaw('head', tokens);
     }
     // Mark the last head entry as a cache boundary (even if budget truncated the window)
     if (entries.length > 0) {
@@ -2899,6 +3005,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
             entries.push(questionEntry);
             entries.push(answerEntry);
             totalTokens += pairTokens;
+            this.rsSummary(summary.level, pairTokens);
           } else {
             const msg = item.msg;
             const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
@@ -2914,6 +3021,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
               content,
             });
             totalTokens += tokens;
+            this.rsRaw('middleRaw', tokens);
           }
         }
       } else {
@@ -2947,6 +3055,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
           entries.push(questionEntry);
           entries.push(answerEntry);
           totalTokens += pairTokens;
+          for (const s of selectedSummaries) this.rsSummary(s.level, s.tokens);
         }
 
         // Sort by position so uncompressed-middle messages and pins both
@@ -2966,6 +3075,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
             content,
           });
           totalTokens += tokens;
+          this.rsRaw('middleRaw', tokens);
         }
       }
     }
@@ -2975,10 +3085,12 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     // budget, the latest messages (the ones the agent actually needs to act
     // on) are preserved and the oldest recent-window messages are dropped.
     const effectiveRecentStart = Math.max(recentStart, headEnd);
-    this.emitRecentNewestFirst(entries, store, messages, effectiveRecentStart, msgCap, maxTokens, totalTokens);
+    const tailStats = this.emitRecentNewestFirst(entries, store, messages, effectiveRecentStart, msgCap, maxTokens, totalTokens);
+    this.rsRaw('tail', tailStats.tokens, tailStats.messages);
 
     this.trimOrphanedToolUse(entries);
     this.pruneToolEntries(entries);
+    this.rsEnd();
     return entries;
   }
 
@@ -3233,6 +3345,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     };
 
     const response = await ctx.membrane.complete(request, { formatter: this.nativeFormatter });
+    // Text-only on purpose: summarizer scratch thinking is not agent history
     return response.content
       .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
       .map(b => b.text)

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -224,8 +224,6 @@ export interface Chunk {
   tokens: number;
   /** Whether this chunk has been compressed */
   compressed: boolean;
-  /** The diary entry if compressed (legacy mode) */
-  diary?: string;
   /** ID of the L1 SummaryEntry (hierarchical mode) */
   summaryId?: string;
   /** Phase type tag (set by KnowledgeStrategy for semantic chunking) */
@@ -1065,9 +1063,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
       if (!chunk || chunk.compressed) return;
 
-      this.pendingCompression = this.config.hierarchical
-        ? this.compressChunkHierarchical(chunk, ctx)
-        : this.compressChunkLegacy(chunk, ctx);
+      this.pendingCompression = this.compressChunkHierarchical(chunk, ctx);
 
       try {
         await this.pendingCompression;
@@ -1141,9 +1137,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     if (this.config.adaptiveResolution) {
       entries = this.selectAdaptive(store, budget);
     } else {
-      entries = this.config.hierarchical
-        ? this.selectHierarchical(store, budget)
-        : this.selectLegacy(store, log, budget);
+      entries = this.selectHierarchical(store, budget);
     }
     // Single post-pass across every compile path: strip stale images to text
     // placeholders so the live image payload stays bounded regardless of how
@@ -1220,130 +1214,6 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     };
   }
 
-  // ============================================================================
-  // Legacy (single-level) path
-  // ============================================================================
-
-  protected selectLegacy(
-    store: MessageStoreView,
-    _log: ContextLogView,
-    budget: TokenBudget
-  ): ContextEntry[] {
-    const entries: ContextEntry[] = [];
-    const maxTokens = budget.maxTokens - budget.reserveForResponse;
-    let totalTokens = 0;
-    const messages = store.getAll();
-    const msgCap = this.config.maxMessageTokens;
-
-    // 1. Head window: preserved verbatim as raw copies
-    const headStart = this.getHeadWindowStartIndex(store);
-    const headEnd = this.getHeadWindowEnd(store);
-    for (let i = headStart; i < headEnd && i < messages.length; i++) {
-      const msg = messages[i];
-      const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
-      const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
-      if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
-
-      entries.push({
-        index: entries.length,
-        sourceMessageId: msg.id,
-        sourceRelation: 'copy',
-        participant: msg.participant,
-        content,
-      });
-      totalTokens += tokens;
-    }
-    // Mark the last head entry as a cache boundary (even if budget truncated the window)
-    if (entries.length > 0) {
-      entries[entries.length - 1].cacheMarker = true;
-    }
-
-    // 2. Middle zone: compressed chunks as diary pairs, uncompressed as raw messages.
-    const rawRecentStart = this.getRecentWindowStart(store);
-    // Track which message IDs are covered by chunks
-    const coveredByChunks = new Set<string>();
-
-    for (const chunk of this.chunks) {
-      for (const m of chunk.messages) coveredByChunks.add(m.id);
-
-      if (chunk.compressed && chunk.diary) {
-        const contextLabel = this.config.summaryContextLabel ?? 'Here is a summary of earlier conversation context:';
-        const summaryParticipant = this.config.summaryParticipant ?? 'Summary';
-
-        const questionEntry: ContextEntry = {
-          index: entries.length,
-          participant: 'Context Manager',
-          content: [{ type: 'text', text: contextLabel }],
-          sourceRelation: 'derived',
-        };
-
-        // Synthesised summary turns must respect maxMessageTokens just like raw
-        // copies do — otherwise a runaway diary can starve recent messages.
-        const answerContent: ContentBlock[] = [{ type: 'text', text: chunk.diary }];
-        const answerEntry: ContextEntry = {
-          index: entries.length + 1,
-          participant: summaryParticipant,
-          content: msgCap > 0 ? this.truncateContent(answerContent, msgCap) : answerContent,
-          sourceRelation: 'derived',
-        };
-
-        const pairTokens = this.estimateTokens(questionEntry.content) +
-                           this.estimateTokens(answerEntry.content);
-
-        if (this.isOverBudget(totalTokens + pairTokens, maxTokens)) break;
-
-        entries.push(questionEntry);
-        entries.push(answerEntry);
-        totalTokens += pairTokens;
-      } else {
-        // Uncompressed: emit raw messages so they aren't lost
-        for (const msg of chunk.messages) {
-          const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
-          const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
-          if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
-
-          entries.push({
-            index: entries.length,
-            sourceMessageId: msg.id,
-            sourceRelation: 'copy',
-            participant: msg.participant,
-            content,
-          });
-          totalTokens += tokens;
-        }
-      }
-    }
-
-    // Emit gap messages in the compressible zone not covered by any chunk.
-    // Compressible zone: [0, headStart) ∪ [headEnd, rawRecentStart)
-    for (let i = 0; i < rawRecentStart && i < messages.length; i++) {
-      // Skip head window messages (already emitted verbatim above)
-      if (i >= headStart && i < headEnd) continue;
-      if (coveredByChunks.has(messages[i].id)) continue;
-      const msg = messages[i];
-      const content = msgCap > 0 ? this.truncateContent(msg.content, msgCap) : msg.content;
-      const tokens = msgCap > 0 ? Math.min(store.estimateTokens(msg), msgCap + 50) : store.estimateTokens(msg);
-      if (this.isOverBudget(totalTokens + tokens, maxTokens)) break;
-
-      entries.push({
-        index: entries.length,
-        sourceMessageId: msg.id,
-        sourceRelation: 'copy',
-        participant: msg.participant,
-        content,
-      });
-      totalTokens += tokens;
-    }
-
-    // 3. Recent uncompressed messages (skip those already in head window)
-    const recentStart = Math.max(this.getRecentWindowStart(store), headEnd);
-    this.emitRecentNewestFirst(entries, store, messages, recentStart, msgCap, maxTokens, totalTokens);
-
-    this.trimOrphanedToolUse(entries);
-    this.pruneToolEntries(entries);
-    return entries;
-  }
-
   /**
    * Emit recent-window messages, evicting OLDEST-first when the budget is tight.
    *
@@ -1399,99 +1269,6 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         content,
       });
     }
-  }
-
-  protected async compressChunkLegacy(chunk: Chunk, ctx: StrategyContext): Promise<void> {
-    if (!ctx.membrane) {
-      throw new Error('No membrane instance for compression');
-    }
-
-    const priorContext = this.buildPriorContextLegacy(chunk, ctx);
-    const chunkContent = this.formatChunkForCompression(chunk);
-
-    const prompt = this.config.diaryUserPrompt ?? this.config.summaryUserPrompt!;
-    const systemPrompt = this.config.diarySystemPrompt ?? this.config.summarySystemPrompt!;
-
-    const messages = [
-      ...priorContext,
-      {
-        participant: 'Context Manager',
-        content: [{ type: 'text' as const, text: prompt.replace('{content}', chunkContent) }],
-      },
-    ];
-
-    const request: NormalizedRequest = {
-      messages: messages.map((m) => ({
-        participant: m.participant,
-        content: m.content,
-      })),
-      system: systemPrompt,
-      config: {
-        model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
-        maxTokens: 2000,
-      },
-    };
-
-    try {
-      const response = await ctx.membrane.complete(request);
-      const diaryText = response.content
-        .filter((b): b is { type: 'text'; text: string } => b.type === 'text')
-        .map((b) => b.text)
-        .join('\n');
-
-      chunk.compressed = true;
-      chunk.diary = diaryText;
-      this._compressionCount++;
-    } catch (error) {
-      console.error('Failed to compress chunk:', error);
-      throw error;
-    }
-  }
-
-  protected buildPriorContextLegacy(chunk: Chunk, ctx: StrategyContext): Array<{
-    participant: string;
-    content: ContentBlock[];
-  }> {
-    const context: Array<{ participant: string; content: ContentBlock[] }> = [];
-
-    for (const prevChunk of this.chunks) {
-      if (prevChunk.index >= chunk.index) break;
-      if (!prevChunk.compressed || !prevChunk.diary) continue;
-
-      context.push({
-        participant: 'Context Manager',
-        content: [{ type: 'text', text: this.config.summaryContextLabel ?? 'Summary of earlier context:' }],
-      });
-      context.push({
-        participant: this.config.summaryParticipant ?? 'Summary',
-        content: [{ type: 'text', text: prevChunk.diary }],
-      });
-    }
-
-    // Find the actual position of this chunk's first message in the full array
-    const messages = ctx.messageStore.getAll();
-    const firstMsgId = chunk.messages[0]?.id;
-    const chunkAbsStart = firstMsgId
-      ? messages.findIndex(m => m.id === firstMsgId)
-      : -1;
-
-    if (chunkAbsStart > 0) {
-      const precedingStart = Math.max(0, chunkAbsStart - 50);
-      let tokens = 0;
-
-      for (let i = chunkAbsStart - 1; i >= precedingStart && tokens < 15000; i--) {
-        const msg = messages[i];
-        if (!msg) break;
-
-        tokens += ctx.messageStore.estimateTokens(msg);
-        context.unshift({
-          participant: msg.participant,
-          content: msg.content,
-        });
-      }
-    }
-
-    return context;
   }
 
   // ============================================================================
@@ -2700,6 +2477,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     // it falls into (preserves KV cache through region transitions).
     const merged = this.mergeAdjacentBodyGroupRaw(entries, store);
 
+    this.pruneToolEntries(merged);
     this.trimOrphanedToolUse(merged);
     // Place ≤4 cache breakpoints across the FINAL ordered entries so the
     // provider can reuse the stable folded prefix — not just the head. With a
@@ -3628,7 +3406,6 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const existing = existingCompressed.get(key);
     if (existing) {
       chunk.compressed = true;
-      chunk.diary = existing.diary;
       chunk.summaryId = existing.summaryId;
     }
 

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -258,12 +258,25 @@ export function isSearchableStrategy(s: ContextStrategy): s is SearchableStrateg
 export interface RenderStats {
   head: { messages: number; tokens: number };
   tail: { messages: number; tokens: number };
+  /**
+   * Raw (L0) messages the renderer kept verbatim in the MIDDLE region — i.e.
+   * neither head nor tail. Under adaptive resolution the picker routinely keeps
+   * older messages raw at a resolution gradient; these are real context tokens
+   * that the head/tail/summary buckets don't capture. (Empty for a pure
+   * hierarchical render with no pinned/uncompressed-middle messages.)
+   */
+  middleRaw: { messages: number; tokens: number };
   summaries: {
     l1: { count: number; tokens: number };
     l2: { count: number; tokens: number };
     l3: { count: number; tokens: number };
   };
   pending: { chunks: number; merges: number };
+  /**
+   * Sum across all buckets — the actual rendered context size. A summary is a
+   * Q/A pair, so it counts as 2 messages here.
+   */
+  total: { messages: number; tokens: number };
 }
 
 /**

--- a/test/image-strip-render-stats.test.ts
+++ b/test/image-strip-render-stats.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression: image stripping must run BEFORE the render-stats snapshot is
+ * committed and BEFORE cache markers are placed, so that
+ *
+ *   (a) RenderStats.total reflects the POST-strip context — the real bytes the
+ *       agent receives — not the pre-strip size that still counts full image
+ *       weight (≈1600 tok) for images replaced by a short text placeholder.
+ *       Pre-fix, getRenderStats() over-reported by ~1592 tok per stripped image
+ *       (and image stripping is on by default: maxLiveImages = 6).
+ *
+ *   (b) cache markers and stripping coexist cleanly: marker positions are
+ *       structural (content-independent, so deterministic across recompiles)
+ *       and a stripped image never resurrects across turns — the live-image
+ *       window is monotonic, so each image strips at most once (one bounded KV
+ *       perturbation, not per-turn flicker).
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-image-strip-render-stats';
+const PLACEHOLDER = 'image dropped from live context';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+}
+
+/** A message carrying one image plus a text label so we can locate it later. */
+function imageMessage(label: string, tokenEstimate = 1600): ContentBlock[] {
+  return [
+    { type: 'image', source: { type: 'base64', data: 'AAAA', mediaType: 'image/png' }, tokenEstimate } as ContentBlock,
+    { type: 'text', text: label },
+  ];
+}
+
+/** Re-derive rendered tokens from the COMPILED output using the strategy's
+ *  default estimator (image -> tokenEstimate ?? 1600, text -> ceil(len/4)).
+ *  The fixtures use only image + text blocks. */
+function renderedTokens(messages: { content: ContentBlock[] }[]): number {
+  let t = 0;
+  for (const m of messages) {
+    for (const b of m.content) {
+      if (b.type === 'image') t += (b as { tokenEstimate?: number }).tokenEstimate ?? 1600;
+      else if (b.type === 'text') t += Math.ceil(b.text.length / 4);
+    }
+  }
+  return t;
+}
+
+function hasLabel(content: ContentBlock[], label: string): boolean {
+  return content.some((b) => b.type === 'text' && b.text.includes(label));
+}
+
+describe('image stripping × render stats', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('(a) total reflects the post-strip size, not the pre-strip image weight', async () => {
+    // Default live-image policy is ON (maxLiveImages: 6). 10 images => 4 stripped.
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy: new AutobiographicalStrategy({
+        adaptiveResolution: true,
+        headWindowTokens: 0,
+        recentWindowTokens: 1_000_000, // keep everything verbatim; isolate the count cap
+      }),
+    });
+    for (let i = 1; i <= 10; i++) manager.addMessage('user', imageMessage(`img-${String(i).padStart(2, '0')}`));
+    const compiled = await manager.compile({ maxTokens: 1_000_000, reserveForResponse: 0 });
+
+    const live = compiled.messages.filter((m) => m.content.some((b) => b.type === 'image')).length;
+    const stripped = compiled.messages.filter((m) => hasLabel(m.content, PLACEHOLDER)).length;
+    assert.equal(live, 6, 'default maxLiveImages keeps 6 images live');
+    assert.equal(stripped, 4, 'the other 4 are stripped to placeholders');
+
+    const rs = manager.getRenderStats();
+    assert.ok(rs, 'stats present after compile');
+
+    // Decisive assertion: total == the ACTUAL rendered size. Pre-fix this was
+    // inflated by the 4 stripped images (~4 * 1592 tok).
+    const expected = renderedTokens(compiled.messages);
+    assert.equal(rs!.total.tokens, expected, 'total.tokens equals the real rendered size');
+
+    // Internal invariant must still hold (total == sum of buckets).
+    const s = rs!.summaries;
+    const bucketSum =
+      rs!.head.tokens + rs!.tail.tokens + rs!.middleRaw.tokens +
+      s.l1.tokens + s.l2.tokens + s.l3.tokens;
+    assert.equal(rs!.total.tokens, bucketSum, 'total == sum of buckets');
+    for (const k of ['head', 'tail', 'middleRaw'] as const) {
+      assert.ok(rs![k].tokens >= 0, `${k} tokens stay non-negative after the strip credit`);
+    }
+
+    // And total must be strictly below the pre-strip size — proves the credit bites.
+    const preStrip = expected + stripped * (1600 - Math.ceil('[image dropped from live context]'.length / 4));
+    assert.ok(rs!.total.tokens < preStrip, 'total is the stripped size, not the pre-strip size');
+
+    manager.close();
+  });
+
+  it('(b) cache markers coexist with stripping; stripped images never resurrect', async () => {
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy: new AutobiographicalStrategy({
+        adaptiveResolution: true,
+        headWindowTokens: 0,
+        recentWindowTokens: 1_000_000,
+        maxLiveImages: 3,
+        imageStripDepthTokens: 0, // isolate the count cap
+      }),
+    });
+    for (let i = 1; i <= 6; i++) manager.addMessage('user', imageMessage(`img-${String(i).padStart(2, '0')}`));
+
+    const c1 = await manager.compile({ maxTokens: 1_000_000, reserveForResponse: 0 });
+    const markers1 = c1.messages.flatMap((m, i) => ((m as { cacheBreakpoint?: boolean }).cacheBreakpoint ? [i] : []));
+    const stripped1 = c1.messages.filter((m) => hasLabel(m.content, PLACEHOLDER)).length;
+
+    assert.ok(markers1.length > 0, 'cache markers are placed');
+    assert.equal(stripped1, 3, 'oldest 3 of 6 images stripped under maxLiveImages:3');
+
+    // Re-compile the SAME store: marker placement is structural (head/tail
+    // membership + index), so positions are identical even though stripping
+    // mutated content. Guards against a future token-sensitive marker pass
+    // being fed pre-strip sizes.
+    const c1b = await manager.compile({ maxTokens: 1_000_000, reserveForResponse: 0 });
+    const markers1b = c1b.messages.flatMap((m, i) => ((m as { cacheBreakpoint?: boolean }).cacheBreakpoint ? [i] : []));
+    assert.deepEqual(markers1b, markers1, 'marker positions are deterministic across recompiles');
+
+    // Cross-turn: append a new image so the live window slides forward. Images
+    // that were already stripped must STAY stripped — monotonic, no flicker
+    // that would churn the cached prefix turn-to-turn.
+    manager.addMessage('user', imageMessage('img-07'));
+    const c2 = await manager.compile({ maxTokens: 1_000_000, reserveForResponse: 0 });
+    for (const label of ['img-01', 'img-02', 'img-03']) {
+      const e = c2.messages.find((m) => hasLabel(m.content, label));
+      assert.ok(e, `${label} still present`);
+      assert.ok(!e!.content.some((b) => b.type === 'image'), `${label} stays stripped after a new turn`);
+    }
+
+    manager.close();
+  });
+});

--- a/test/render-stats.test.ts
+++ b/test/render-stats.test.ts
@@ -1,0 +1,109 @@
+/**
+ * getRenderStats must INSPECT what select() actually rendered, not RECONSTRUCT
+ * a hierarchical view. Regression for the adaptive-resolution case where the
+ * reconstructed pyramid (head/tail windows + every live summary) bore no
+ * relation to the folded output — and had no bucket at all for raw messages the
+ * picker kept verbatim in the middle.
+ */
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+import type { RenderStats } from '../src/types/index.js';
+
+const TEST_STORE_PATH = './test-render-stats';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+}
+function text(t: string): ContentBlock[] {
+  return [{ type: 'text', text: t }];
+}
+
+function assertConsistent(rs: RenderStats): void {
+  const s = rs.summaries;
+  const sumTokens =
+    rs.head.tokens + rs.tail.tokens + rs.middleRaw.tokens +
+    s.l1.tokens + s.l2.tokens + s.l3.tokens;
+  assert.strictEqual(rs.total.tokens, sumTokens, 'total.tokens === sum of bucket tokens');
+  const sumMsgs =
+    rs.head.messages + rs.tail.messages + rs.middleRaw.messages +
+    (s.l1.count + s.l2.count + s.l3.count) * 2;
+  assert.strictEqual(rs.total.messages, sumMsgs, 'total.messages === sum of bucket messages');
+}
+
+describe('getRenderStats — inspect, not reconstruct', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('reflects the actually-rendered raw conversation (every message accounted for once)', async () => {
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy: new AutobiographicalStrategy({ adaptiveResolution: true }),
+    });
+    const N = 8;
+    for (let i = 0; i < N; i++) {
+      manager.addMessage(i % 2 ? 'lena' : 'user', text(`message ${i} ${'x'.repeat(20)}`));
+    }
+    await manager.compile();
+
+    const rs = manager.getRenderStats();
+    assert.ok(rs, 'stats present after compile');
+    assertConsistent(rs!);
+    // Small conversation, no membrane => no compression => no summaries.
+    assert.strictEqual(
+      rs!.summaries.l1.count + rs!.summaries.l2.count + rs!.summaries.l3.count,
+      0,
+      'no summaries for a small raw conversation',
+    );
+    const rawMsgs = rs!.head.messages + rs!.tail.messages + rs!.middleRaw.messages;
+    assert.strictEqual(rawMsgs, N, 'every raw message accounted for exactly once');
+    assert.ok(rs!.total.tokens > 0, 'non-zero rendered tokens');
+    manager.close();
+  });
+
+  it('populates middleRaw for mid-conversation messages the picker keeps verbatim', async () => {
+    // Small head/recent windows push most messages into the MIDDLE region; with
+    // no summaries to fold into, the picker keeps them raw — which the old
+    // reconstruction would have reported as 0 middle / all-pyramid.
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy: new AutobiographicalStrategy({
+        adaptiveResolution: true,
+        headWindowTokens: 100,
+        recentWindowTokens: 100,
+      }),
+    });
+    const N = 20;
+    for (let i = 0; i < N; i++) {
+      manager.addMessage(i % 2 ? 'lena' : 'user', text(`msg ${i} ${'y'.repeat(40)}`));
+    }
+    // Generous budget so nothing is evicted (and the picker doesn't go over-budget).
+    await manager.compile({ maxTokens: 100_000, reserveForResponse: 1_000 });
+
+    const rs = manager.getRenderStats();
+    assert.ok(rs, 'stats present');
+    assertConsistent(rs!);
+    assert.ok(
+      rs!.middleRaw.messages > 0,
+      'middle messages kept raw by the picker must show up in middleRaw (inspect, not reconstruct)',
+    );
+    const rawMsgs = rs!.head.messages + rs!.tail.messages + rs!.middleRaw.messages;
+    assert.strictEqual(rawMsgs, N, 'all raw, all accounted for');
+    manager.close();
+  });
+
+  it('returns a non-null shape (with the new fields) before any compile', async () => {
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy: new AutobiographicalStrategy({ adaptiveResolution: true }),
+    });
+    manager.addMessage('user', text('hi'));
+    const rs = manager.getRenderStats(); // no compile yet -> reconstruction fallback
+    assert.ok(rs, 'fallback stats present');
+    assert.ok(rs!.middleRaw && rs!.total, 'fallback includes middleRaw + total');
+    manager.close();
+  });
+});


### PR DESCRIPTION
Integration branch consolidating adaptive-resolution work toward making it the default strategy.

## Adaptive resolution
- **Supersedes #27** (feat/adaptive-resolution is contained verbatim): adaptive resolution + live-image policy
- Remove dead legacy select path; tool-prune parity in adaptive
- Bound live images in compiled context
- Adaptive-resolution V2 best-fit frontier solver design doc (implementation continues in #28, which is separate work not contained here)

## Signed thinking support (membrane ^0.5.64)
- Bump membrane floor to ^0.5.64 (signed thinking round-trip on yielding paths, redacted_thinking data preservation)
- Token estimation handles `redacted_thinking` payloads and signature-only thinking blocks (`display:'omitted'`)
- Annotate the intentional text-only summarizer-response filters in the autobiographical strategy (summarizer scratch thinking is not agent history; signed thinking is never valid inside a rewritten summary)

Persistence and normalization already pass thinking blocks + signatures through verbatim — verified end-to-end by agent-framework's regression test against a real ContextManager + Chronicle store.

Tests: 154/154 against published membrane 0.5.64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)