### PR TITLE
fix(autobiographical): speculation cap no longer deadlocks compression

### DIFF
--- a/scripts/debug-compile.ts
+++ b/scripts/debug-compile.ts
@@ -50,6 +50,7 @@ async function main() {
   const opt = (k: string, d?: string) => { const i = args.indexOf(k); return i >= 0 ? args[i + 1] : d; };
   const strategyName = (opt('--strategy', 'kv-stable')) as 'kv-stable' | 'flat-profile' | 'oldest-first';
   const cap = Number(opt('--cap', '0.25'));
+  const absBudget = opt('--budget') ? Number(opt('--budget')) : undefined; // absolute token budget; overrides --cap
   const reach = opt('--reach') ? Number(opt('--reach')) : undefined;
   const ns = opt('--ns');
   const full = args.includes('--full');
@@ -67,6 +68,7 @@ async function main() {
     maxMessageTokens: 10000,
     mergeThreshold: 6,
     compressionModel: 'mock',
+    enforceBudget: false,
     foldingStrategy: strategyName,
     ...(reach !== undefined ? { kvStableReachTokens: reach } : {}),
   };
@@ -82,7 +84,7 @@ async function main() {
 
   const messages = cm.getAllMessages();
   const rawTotal = messages.reduce((a, m) => a + estTokens((m as any).content), 0);
-  const budget = Math.round(rawTotal * cap);
+  const budget = absBudget !== undefined ? absBudget : Math.round(rawTotal * cap);
 
   // Construct context — NO inference.
   let result;

--- a/scripts/inspect-store.ts
+++ b/scripts/inspect-store.ts
@@ -54,10 +54,13 @@ async function main() {
     recentWindowTokens: 30000,
     mergeThreshold: 6,
   });
+  const nsIdx = args.indexOf('--ns');
+  const ns = nsIdx >= 0 ? args[nsIdx + 1] : undefined;
   const manager = await ContextManager.open({
     path: storePath,
     strategy,
     membrane: makeMockMembrane() as any,
+    ...(ns ? { namespace: ns } : {}),
   });
 
   const messages = manager.getAllMessages();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@
 export { ContextManager } from './context-manager.js';
 export type { ContextManagerConfig } from './context-manager.js';
 
+// Phase channel (liveness-watchdog observability hook)
+export { phaseChannel, enterPhase, withPhase, withPhaseAsync } from './phase-channel.js';
+
 // Storage
 export { MessageStore } from './message-store.js';
 export type { MessageStoreEvent, MessageStoreListener } from './message-store.js';

--- a/src/phase-channel.ts
+++ b/src/phase-channel.ts
@@ -1,0 +1,57 @@
+/**
+ * Phase channel — a process-wide observability hook for labelling the
+ * synchronous operation the main thread is currently running.
+ *
+ * Long synchronous work (context assembly, compression, merge-graph walks) can
+ * wedge the single-threaded event loop. An external liveness watchdog (in the
+ * host/agent-framework) can detect the wedge but not name what was running —
+ * unless the running code labels itself here. This module is a no-op sink by
+ * default; the watchdog installs `report` on start so labels reach its wedge
+ * report. context-manager owns the channel (no upward dependency); the watchdog
+ * (which depends on context-manager) wires it.
+ */
+const stack: string[] = [];
+
+export const phaseChannel: {
+  /** Installed by the watchdog; receives the current (innermost) phase label. */
+  report: (label: string) => void;
+} = {
+  report: () => {},
+};
+
+/** Enter a named phase. Returns a disposer that restores the previous phase. */
+export function enterPhase(label: string): () => void {
+  stack.push(label);
+  phaseChannel.report(label);
+  let done = false;
+  return () => {
+    if (done) return;
+    done = true;
+    // Pop this label (tolerate out-of-order disposal defensively).
+    const idx = stack.lastIndexOf(label);
+    if (idx !== -1) stack.splice(idx, 1);
+    phaseChannel.report(stack[stack.length - 1] ?? 'idle');
+  };
+}
+
+/** Run a synchronous section under a phase label (nesting-safe). */
+export function withPhase<T>(label: string, fn: () => T): T {
+  const leave = enterPhase(label);
+  try {
+    return fn();
+  } finally {
+    leave();
+  }
+}
+
+/** Run an async section under a phase label. Note: this labels across awaits,
+ *  which is what we want — the synchronous spans inside (where a wedge would
+ *  occur) stay attributed to this phase. */
+export async function withPhaseAsync<T>(label: string, fn: () => Promise<T>): Promise<T> {
+  const leave = enterPhase(label);
+  try {
+    return await fn();
+  } finally {
+    leave();
+  }
+}

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1,6 +1,7 @@
 import type { JsStore } from '@animalabs/chronicle';
 import type { Membrane, NormalizedRequest, ContentBlock, CompleteOptions } from '@animalabs/membrane';
 import { NativeFormatter } from '@animalabs/membrane';
+import { phaseChannel } from '../phase-channel.js';
 import type {
   ContextStrategy,
   ResettableStrategy,
@@ -1050,6 +1051,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   }
 
   async tick(ctx: StrategyContext): Promise<void> {
+    phaseChannel.report('compress-tick'); // liveness-watchdog phase
     if (this.pendingCompression) return;
 
     if (!ctx.membrane) {
@@ -1403,6 +1405,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * No system prompt — framing via message structure only.
    */
   protected async compressChunkHierarchical(chunk: Chunk, ctx: StrategyContext): Promise<void> {
+    phaseChannel.report('compress-chunk'); // liveness-watchdog phase
     if (!ctx.membrane) {
       throw new Error('No membrane instance for compression');
     }
@@ -1681,6 +1684,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * summaries when the queue eventually drains.
    */
   protected checkMergeThreshold(): void {
+    phaseChannel.report('merge-threshold'); // liveness-watchdog phase
     if (this.config.speculativeProduction) {
       this.checkMergeThresholdRecursive();
       return;
@@ -2148,6 +2152,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * See `docs/adaptive-resolution-design.md` §3, §5.
    */
   protected selectAdaptive(store: MessageStoreView, budget: TokenBudget): ContextEntry[] {
+    phaseChannel.report('context-build'); // liveness-watchdog phase
     this.rsBegin();
     const entries: ContextEntry[] = [];
     const maxTokens = budget.maxTokens - budget.reserveForResponse;
@@ -2825,6 +2830,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * Matches moltbot's budget waterfall: L3 → L2 → L1 with unused budget flowing down.
    */
   protected selectHierarchical(store: MessageStoreView, budget: TokenBudget): ContextEntry[] {
+    phaseChannel.report('context-build'); // liveness-watchdog phase
     this.rsBegin();
     const entries: ContextEntry[] = [];
     const maxTokens = budget.maxTokens - budget.reserveForResponse;

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1005,9 +1005,18 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    */
   protected driveSpeculativeDrain(ctx: StrategyContext): void {
     if (this.pendingCompression) return;
-    if (this.compressionQueue.length === 0 && this.mergeQueue.length === 0) return;
-    if (this.isAtSpeculativeCap()) return;
-    if (!this.shouldCompressPreflight()) return;
+    // Merges consolidate existing L_k summaries into L_{k+1} and REDUCE the
+    // unmerged-L1 count; L1 compression PRODUCES new unmerged L1s. The
+    // speculation cap / preflight throttle *production* only — they must never
+    // gate merges, otherwise exceeding the cap (e.g. after a manual backfill)
+    // permanently deadlocks the drain: too many unmerged L1s trips the cap,
+    // which blocks the very merges that would bring the count back down.
+    const hasMerges = this.config.hierarchical === true && this.mergeQueue.length > 0;
+    const hasCompression = this.compressionQueue.length > 0;
+    if (!hasCompression && !hasMerges) return;
+    // Only bail when the *sole* available work is L1 compression that the cap
+    // or preflight currently forbids. Merge work always proceeds.
+    if (!hasMerges && (this.isAtSpeculativeCap() || !this.shouldCompressPreflight())) return;
 
     const beforeChunks = this.compressionQueue.length;
     const beforeMerges = this.mergeQueue.length;
@@ -1030,14 +1039,23 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   }
 
   /**
-   * Whether the strategy's pending+queued L1 budget has reached the cap
+   * Whether the count of *produced, unmerged* L1 summaries has reached the cap
    * configured by `maxSpeculativeL1s`. If no cap is set, always false.
+   *
+   * The cap bounds how many L1 summaries may sit un-consolidated before the
+   * strategy must merge them into L_{k+1} (bounding prefix churn / merge debt).
+   * It deliberately does NOT count the pending `compressionQueue`: that queue is
+   * the backlog of work to be *drained*, not produced summaries. Counting it
+   * here would let a large backlog permanently trip the cap and block the very
+   * compression that would clear it — a deadlock (merges relieve the cap, but
+   * compression of the backlog never resumes). The throttle is on produced L1s;
+   * the queue drains freely, with merges keeping the unmerged count under the cap.
    */
   protected isAtSpeculativeCap(): boolean {
     const cap = this.config.maxSpeculativeL1s;
     if (cap === undefined || cap < 0) return false;
     const unmergedL1s = this.summaries.filter(s => s.level === 1 && !s.mergedInto).length;
-    return unmergedL1s + this.compressionQueue.length > cap;
+    return unmergedL1s > cap;
   }
 
   /**
@@ -1059,8 +1077,11 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       return;
     }
 
-    // Priority 1: Compress raw chunks → L1
-    if (this.compressionQueue.length > 0) {
+    // Priority 1: Compress raw chunks → L1. Skipped while at the speculative
+    // cap (maxSpeculativeL1s) so we don't pile up more unmerged L1s; the merge
+    // priority below still runs to consolidate existing L1s and relieve the cap.
+    // No cap configured → isAtSpeculativeCap() is always false → unchanged.
+    if (this.compressionQueue.length > 0 && !this.isAtSpeculativeCap()) {
       const chunkIndex = this.compressionQueue.shift()!;
       const chunk = this.chunks[chunkIndex];
 

--- a/test/speculation-cap.test.ts
+++ b/test/speculation-cap.test.ts
@@ -7,9 +7,15 @@
  * speculatively-built L1s before there was any real budget pressure.
  *
  * Post-fix:
- *  - `maxSpeculativeL1s` caps the count of (unmerged L1s + queued chunks).
- *    When at cap, `onNewMessage` defers auto-tick — chunks still queue,
- *    but compression doesn't fire until an explicit tick() / compile().
+ *  - `maxSpeculativeL1s` caps the count of *produced, unmerged* L1 summaries.
+ *    When at cap, `onNewMessage` defers auto-tick L1 production — chunks still
+ *    queue, but compression doesn't fire until merges bring the unmerged count
+ *    back under the cap (or an explicit tick() / compile()).
+ *  - The cap does NOT count the pending compression backlog and does NOT gate
+ *    merges: merges consolidate L1s into L_{k+1} and REDUCE the unmerged count,
+ *    so gating them would deadlock (too many unmerged L1s blocks the merges that
+ *    would relieve the cap, and a large backlog blocks the compression that
+ *    would drain it). See the "does not deadlock" regression suite below.
  *  - `shouldCompressPreflight()` is overridable so subclasses can add
  *    custom predictive scheduling.
  */
@@ -176,6 +182,114 @@ describe('AutobiographicalStrategy — speculation cap (gap #8)', () => {
 
     assert.ok(strategy.hasQueuedChunk(), 'sanity: chunk formed');
     assert.equal(strategy.tickCalls, 0, 'preflight=false must block auto-tick');
+    manager.close();
+  });
+});
+
+/**
+ * Regression: the speculation cap must throttle L1 *production* without
+ * deadlocking. Before this fix, `isAtSpeculativeCap()` counted
+ * `unmergedL1s + compressionQueue.length` and gated the *entire* drain. A store
+ * that accumulated more unmerged L1s than the cap (e.g. a manual backfill) could
+ * never recover: the cap blocked the merges that would reduce the count, and the
+ * backlog blocked the compression that would drain it. (Observed live: an agent
+ * with 79 unmerged L1s, cap 36, and 13 queued merges sat frozen indefinitely.)
+ */
+describe('AutobiographicalStrategy — speculation cap does not deadlock (regression)', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  class DrainStrategy extends AutobiographicalStrategy {
+    public mergeRuns = 0;
+
+    seedL1(content: string): SummaryEntry {
+      const entry: SummaryEntry = {
+        id: `L1-${this.nextSummaryIdCounter()}`,
+        level: 1,
+        content,
+        tokens: Math.ceil(content.length / 4),
+        sourceLevel: 0,
+        sourceIds: ['x'],
+        sourceRange: { first: 'x', last: 'x' },
+        created: Date.now(),
+      };
+      this.pushSummary(entry);
+      return entry;
+    }
+    queueMerge(ids: string[]): void {
+      (this as any).enqueueMerge({ level: 2, sourceIds: ids });
+    }
+    atCap(): boolean { return (this as any).isAtSpeculativeCap(); }
+    unmergedL1(): number {
+      return (this as any).summaries.filter((s: SummaryEntry) => s.level === 1 && !s.mergedInto).length;
+    }
+    get mergeQ(): unknown[] { return (this as any).mergeQueue; }
+    get compQ(): number[] { return (this as any).compressionQueue; }
+
+    // Isolate the drain/cap gating from executeMerge's message-store coupling:
+    // simulate a successful merge by marking the sources merged.
+    protected override async executeMerge(_level: any, sourceIds: string[]): Promise<void> {
+      this.mergeRuns++;
+      for (const id of sourceIds) {
+        const s = (this as any).summaries.find((x: SummaryEntry) => x.id === id);
+        if (s) (s as any).mergedInto = 'L2-test';
+      }
+    }
+  }
+
+  it('cap counts produced unmerged L1s only — a compression backlog must not trip it', async () => {
+    const strategy = new DrainStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 5,
+      maxSpeculativeL1s: 5,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({ path: TEST_STORE_PATH, strategy });
+
+    strategy.seedL1('only one'); // 1 produced unmerged L1
+    for (let i = 0; i < 100; i++) strategy.compQ.push(i); // huge pending backlog
+
+    assert.equal(
+      strategy.atCap(),
+      false,
+      'a 100-deep compression backlog with 1 produced L1 must NOT trip a cap of 5 (pre-fix deadlock)',
+    );
+
+    for (let i = 0; i < 5; i++) strategy.seedL1(`x${i}`); // now 6 produced unmerged > 5
+    assert.equal(strategy.atCap(), true, 'six produced unmerged L1s exceed the cap of 5');
+
+    manager.close();
+  });
+
+  it('over-cap with queued merges still drains merges, then the cap clears', async () => {
+    const membrane = { complete: async () => ({ content: [{ type: 'text', text: '[mock]' }] }) };
+    const strategy = new DrainStrategy({
+      headWindowTokens: 0,
+      recentWindowTokens: 5,
+      maxSpeculativeL1s: 3,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+      membrane: membrane as any,
+    });
+
+    const ids: string[] = [];
+    for (let i = 0; i < 8; i++) ids.push(strategy.seedL1(`s${i}`).id); // 8 unmerged > cap 3
+    strategy.queueMerge(ids.slice(0, 6)); // one L2 merge over 6 of them
+
+    assert.equal(strategy.atCap(), true, 'precondition: over the cap');
+    assert.equal(strategy.mergeQ.length, 1, 'precondition: a merge is queued');
+
+    await manager.tick(); // pre-fix: bailed at the cap → permanent deadlock
+
+    assert.equal(strategy.mergeRuns, 1, 'merge must run even while over the speculative cap');
+    assert.equal(strategy.mergeQ.length, 0, 'merge dequeued after success');
+    assert.equal(strategy.unmergedL1(), 2, '6 of 8 L1s consolidated');
+    assert.equal(strategy.atCap(), false, 'cap cleared → L1 compression can resume');
+
     manager.close();
   });
 });


### PR DESCRIPTION
Brings `dev` into `main` (2 commits, clean fast-forward). Primary change is a fix for a compression deadlock observed live across the Connectome agent fleet.

## The bug
`isAtSpeculativeCap()` counted `unmergedL1s + compressionQueue.length` and gated the **entire** speculative drain. Once a store accumulated more unmerged L1s than `maxSpeculativeL1s` (e.g. via a manual backfill), it could never recover:
- the cap blocked the **merges** that would reduce the unmerged-L1 count, and
- the compression **backlog** kept the cap tripped, blocking the compression that would drain it.

Observed on Lena: 79 unmerged L1s, cap 36, 13 queued merges — frozen for weeks; ~3,000 messages went uncompressed.

## The fix (cap throttles L1 *production* only, never merges)
- `isAtSpeculativeCap()` counts produced unmerged L1s only, not the pending queue.
- `driveSpeculativeDrain()` lets merge work proceed past the cap/preflight; bails only when the sole available work is cap-forbidden L1 compression.
- `tick()` skips L1 compression while at cap so merges can run and relieve it.

## Verification
- Replayed on a copy of Lena's real store (mock membrane): the 142-chunk backlog drains to completion in 184 ticks, cascading up to a new L4, settling at 5 unmerged L1s — no deadlock, no stall.
- 2 regression tests added; full suite **158/158**.
- Deployed live to lena/cairn/tilde/opus4 — compression confirmed draining.

Also includes `e678840` (phase channel for liveness-watchdog attribution) and `--budget`/`--ns` knobs on the debug-compile/inspect-store scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)