### PR TITLE
fix(autobiographical): persist chunk boundaries; compress only closed chunks

### DIFF
--- a/scripts/repair-pyramid.ts
+++ b/scripts/repair-pyramid.ts
@@ -1,0 +1,201 @@
+/**
+ * Repair a contaminated autobiographical memory pyramid.
+ *
+ * Background (2026-07 fleet audit): the pre-chunk-persistence code minted
+ * duplicate L1s — prefix-generation families from eager partial-tail
+ * compression, and same-range siblings from restart re-consolidation
+ * storms. All generations stayed in the log, rendered on the unmerged
+ * frontier, and merged upward together, baking N-fold repetition into
+ * L2/L3 prose (the redundancy amplifier behind the "68 initiations"
+ * class of distortions).
+ *
+ * This script:
+ *   1. Selects L1 KEEPERS — from the `autobio:chunks` records when present
+ *      (post-migration store), else by the same coverage algorithm the
+ *      migration uses (start asc, span desc; fully-covered L1s are stale).
+ *   2. PRUNES all other L1s from the summaries log.
+ *   3. WIPES every L2 with at least one pruned child, and every L3 with a
+ *      wiped/pruned child — their prose was written from duplicates.
+ *   4. Clears `mergedInto` on surviving children of wiped parents, so the
+ *      normal merge machinery regenerates the pyramid from clean L1s
+ *      (run scripts/drain-generic-style offline drain afterwards, or let
+ *      the live agent re-merge gradually).
+ *   5. Drops mergeQueue entries referencing pruned/wiped ids.
+ *
+ * DRY-RUN by default; pass --apply to write. Writes are full-array
+ * Snapshots of the summaries + mergeQueue states (chronicle keeps the full
+ * pre-repair history in the record log — nothing is destroyed, and the
+ * repair itself is one more auditable state transition).
+ *
+ * ALWAYS back up the session dir first and validate on a copy.
+ *
+ * Usage:
+ *   node dist/scripts/repair-pyramid.js <store-path> <namespace> [--apply]
+ * e.g.
+ *   node dist/scripts/repair-pyramid.js ~/mythos-cm/data/sessions/<id> agents/mythos
+ */
+
+import { JsStore } from '@animalabs/chronicle';
+
+interface SummaryEntry {
+  id: string;
+  level: number;
+  content: string;
+  tokens: number;
+  sourceLevel: number;
+  sourceIds: string[];
+  sourceRange?: { first: string; last: string };
+  mergedInto?: string;
+  created: number;
+  phaseType?: string;
+}
+
+interface ChunkRecord {
+  id: string;
+  sourceIds: string[];
+  compressed: boolean;
+  summaryId?: string;
+}
+
+const args = process.argv.slice(2);
+const apply = args.includes('--apply');
+const [storePath, namespace] = args.filter(a => !a.startsWith('--'));
+if (!storePath || !namespace) {
+  console.error('usage: repair-pyramid <store-path> <namespace> [--apply]');
+  process.exit(2);
+}
+
+const SUMS = `${namespace}/autobio:summaries`;
+const CHUNKS = `${namespace}/autobio:chunks`;
+const MERGEQ = `${namespace}/autobio:mergeQueue`;
+
+const store = JsStore.open({ path: storePath });
+
+// ---- load, mirroring loadPersistedState (empty filter + id dedupe) ----
+const rawSums = store.getStateJson(SUMS);
+const loaded: SummaryEntry[] = (Array.isArray(rawSums) ? rawSums : []).filter(
+  (s: SummaryEntry | null) => s && typeof s.content === 'string' && s.content.trim().length > 0,
+);
+const byId = new Map<string, SummaryEntry>();
+for (const s of loaded) {
+  const prev = byId.get(s.id);
+  if (!prev) byId.set(s.id, s);
+  else if (!prev.mergedInto && s.mergedInto) byId.set(s.id, s);
+}
+const summaries = [...byId.values()];
+const l1s = summaries.filter(s => s.level === 1 && Array.isArray(s.sourceIds) && s.sourceIds.length > 0);
+
+const messages = store.getStateJson('messages');
+const msgIndex = new Map<string, number>();
+(Array.isArray(messages) ? messages : []).forEach((m: { id?: string }, i: number) => {
+  if (m && typeof m.id === 'string') msgIndex.set(m.id, i);
+});
+
+// ---- 1. keepers ----
+const records = store.getStateJson(CHUNKS);
+const chunkRecords: ChunkRecord[] = Array.isArray(records) ? records : [];
+let keepers: Set<string>;
+let keeperSource: string;
+if (chunkRecords.length > 0) {
+  keepers = new Set(chunkRecords.map(r => r.summaryId).filter((x): x is string => typeof x === 'string'));
+  keeperSource = `chunk records (${chunkRecords.length})`;
+  for (const id of keepers) {
+    if (!byId.has(id)) {
+      console.error(`FATAL: chunk record points at missing summary ${id} — reconcile before repairing`);
+      process.exit(3);
+    }
+  }
+} else {
+  // Same algorithm as AutobiographicalStrategy.migrateChunkRecords.
+  keepers = new Set();
+  const covered = new Set<string>();
+  const sorted = [...l1s].sort((a, b) => {
+    const sa = msgIndex.get(a.sourceIds[0]) ?? Number.MAX_SAFE_INTEGER;
+    const sb = msgIndex.get(b.sourceIds[0]) ?? Number.MAX_SAFE_INTEGER;
+    return sa - sb || b.sourceIds.length - a.sourceIds.length;
+  });
+  for (const s of sorted) {
+    if (!s.sourceIds.some(id => msgIndex.has(id))) continue; // fully orphaned
+    if (s.sourceIds.every(id => covered.has(id))) continue;  // stale generation
+    for (const id of s.sourceIds) covered.add(id);
+    keepers.add(s.id);
+  }
+  keeperSource = 'coverage algorithm (no chunk records)';
+}
+
+// ---- 2..4. prune / wipe / unmerge ----
+const prunedL1 = new Set(l1s.filter(s => !keepers.has(s.id)).map(s => s.id));
+// Ghost L1s (no live sourceIds, not keepers) are pruned too.
+for (const s of summaries.filter(x => x.level === 1 && !keepers.has(x.id))) prunedL1.add(s.id);
+
+const children = new Map<string, SummaryEntry[]>();
+for (const s of summaries) {
+  if (s.mergedInto) {
+    const list = children.get(s.mergedInto) ?? [];
+    list.push(s);
+    children.set(s.mergedInto, list);
+  }
+}
+
+const wiped = new Set<string>();
+for (const l2 of summaries.filter(s => s.level === 2)) {
+  const kids = children.get(l2.id) ?? [];
+  if (kids.some(k => prunedL1.has(k.id))) wiped.add(l2.id);
+}
+for (const l3 of summaries.filter(s => s.level === 3)) {
+  const kids = children.get(l3.id) ?? [];
+  if (kids.some(k => wiped.has(k.id) || prunedL1.has(k.id))) wiped.add(l3.id);
+}
+// Cascade upward defensively for any deeper levels.
+let grew = true;
+while (grew) {
+  grew = false;
+  for (const s of summaries.filter(x => x.level > 3)) {
+    if (wiped.has(s.id)) continue;
+    const kids = children.get(s.id) ?? [];
+    if (kids.some(k => wiped.has(k.id) || prunedL1.has(k.id))) { wiped.add(s.id); grew = true; }
+  }
+}
+
+const survivors: SummaryEntry[] = [];
+let unmerged = 0;
+for (const s of summaries) {
+  if (prunedL1.has(s.id) || wiped.has(s.id)) continue;
+  if (s.mergedInto && (wiped.has(s.mergedInto) || prunedL1.has(s.mergedInto))) {
+    const { mergedInto: _drop, ...rest } = s;
+    survivors.push(rest as SummaryEntry);
+    unmerged++;
+  } else {
+    survivors.push(s);
+  }
+}
+
+// ---- 5. merge queue ----
+const rawQueue = store.getStateJson(MERGEQ);
+const mergeQueue: Array<{ level: number; sourceIds: string[] }> = Array.isArray(rawQueue) ? rawQueue : [];
+const removedIds = new Set([...prunedL1, ...wiped]);
+const cleanQueue = mergeQueue.filter(m => !m.sourceIds.some(id => removedIds.has(id)));
+
+// ---- report ----
+const count = (lvl: number, set: Set<string>) =>
+  summaries.filter(s => s.level === lvl && set.has(s.id)).length;
+console.log(`store:        ${storePath}`);
+console.log(`namespace:    ${namespace}`);
+console.log(`keepers from: ${keeperSource}`);
+console.log(`summaries:    ${summaries.length} loaded (${loaded.length - summaries.length} duplicate-id copies collapsed)`);
+console.log(`L1: ${l1s.length} total → keep ${keepers.size}, prune ${prunedL1.size}`);
+console.log(`L2: ${summaries.filter(s => s.level === 2).length} total → wipe ${count(2, wiped)}`);
+console.log(`L3: ${summaries.filter(s => s.level === 3).length} total → wipe ${count(3, wiped)}`);
+console.log(`survivors:    ${survivors.length} (${unmerged} returned to unmerged frontier)`);
+console.log(`merge queue:  ${mergeQueue.length} → ${cleanQueue.length}`);
+
+if (!apply) {
+  console.log('\nDRY RUN — nothing written. Pass --apply to write (back up first!).');
+  store.close();
+  process.exit(0);
+}
+
+store.setStateJson(SUMS, survivors);
+store.setStateJson(MERGEQ, cleanQueue);
+store.close();
+console.log('\nAPPLIED. Run the offline merge drain (or let the agent re-merge live).');

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -236,6 +236,36 @@ export interface Chunk {
   summaryId?: string;
   /** Phase type tag (set by KnowledgeStrategy for semantic chunking) */
   phaseType?: string;
+  /** ID of the persisted ChunkRecord backing this chunk (chunk persistence). */
+  recordId?: string;
+}
+
+/**
+ * Persisted chunk boundary, one per CLOSED chunk, stored in the
+ * `autobio:chunks` chronicle state slot (append_log, branch-aware).
+ *
+ * Records OWN the past: once a chunk closes, its membership is a persisted
+ * fact — rebuilds and restarts materialize chunks from records instead of
+ * recomputing boundaries from the running token sum. This is the fix for the
+ * 2026-07 re-consolidation storms: boundary inputs (config knobs, head
+ * window, token estimates, message mutations) could shift across restarts,
+ * the old exact-sourceIds-match recovery then failed, and whole stretches of
+ * already-summarized history were re-compressed into duplicate L1s.
+ *
+ * Membership is by message ID (never index), so edits/redactions degrade a
+ * record gracefully instead of re-keying its neighbors.
+ */
+export interface ChunkRecord {
+  /** Stable record id ("c-<n>"). */
+  id: string;
+  /** Exact message IDs of the closed chunk, in order. */
+  sourceIds: string[];
+  /** Whether the chunk's L1 summary has been produced. */
+  compressed: boolean;
+  /** ID of the L1 SummaryEntry, once compressed. */
+  summaryId?: string;
+  /** Phase type tag (KnowledgeStrategy semantic chunking). */
+  phaseType?: string;
 }
 
 /**
@@ -318,6 +348,23 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    */
   protected _drainProgress = 0;
 
+  /**
+   * In-memory mirror of the persisted chunk records (autobio:chunks slot).
+   * Loaded in `loadPersistedState`, appended to when a chunk closes,
+   * updated by ID when its L1 lands.
+   */
+  protected chunkRecords: ChunkRecord[] = [];
+  protected chunkIdCounter = 0;
+  /**
+   * Fail-closed latch: set when most persisted records resolve to zero live
+   * messages (the messages-chain-break signature). While set, NO compression
+   * runs — duplicate memories are strictly worse than delayed compression.
+   */
+  protected chunkRecordsOrphaned = false;
+  private _orphanWarned = false;
+  /** Record ids whose compression was refused by the L1 overlap guard. */
+  private _overlapBlocked = new Set<string>();
+
   // Hierarchical state
   protected summaries: SummaryEntry[] = [];
   protected summaryIdCounter = 0;
@@ -334,6 +381,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   /** Namespace for state-id scoping. Set in `initialize()`. */
   protected ns: string = '';
   protected get summariesStateId(): string { return `${this.ns}/autobio:summaries`; }
+  protected get chunksStateId(): string { return `${this.ns}/autobio:chunks`; }
   protected get counterStateId(): string { return `${this.ns}/autobio:counter`; }
   protected get mergeQueueStateId(): string { return `${this.ns}/autobio:mergeQueue`; }
   protected get pinsStateId(): string { return `${this.ns}/autobio:pins`; }
@@ -486,7 +534,108 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         break;
       }
     }
+    // Legacy stores (pre chunk-persistence) have L1 summaries but no chunk
+    // records — synthesize records from L1 sourceIds before the first
+    // rebuild, so covered ground is owned and never re-compressed.
+    this.migrateChunkRecords(ctx.messageStore);
     this.rebuildChunks(ctx.messageStore);
+  }
+
+  /**
+   * Whether chunk boundaries are persisted to the `autobio:chunks` slot and
+   * own the past. Subclasses with their own chunking (KnowledgeStrategy's
+   * semantic phases) opt out and keep the legacy recompute-every-rebuild
+   * behavior.
+   */
+  protected get chunkPersistenceEnabled(): boolean {
+    return true;
+  }
+
+  /**
+   * One-time lazy migration: a store with L1 summaries but an empty chunks
+   * slot predates chunk persistence. Each L1's sourceIds ARE the historical
+   * chunk boundary — synthesize a compressed record per L1, in message
+   * order. Stale generations from the old partial-tail compression bug
+   * (an L1 whose messages are ALL already covered by records synthesized so
+   * far — prefix families, same-range duplicates) get NO record; coverage is
+   * what blocks re-compression, and the repair tooling prunes their content
+   * separately.
+   */
+  protected migrateChunkRecords(store: MessageStoreView): void {
+    if (!this.chunkPersistenceEnabled || !this.store) return;
+    if (this.chunkRecords.length > 0) return;
+    const l1s = this.summaries.filter(s => s.level === 1 && Array.isArray(s.sourceIds) && s.sourceIds.length > 0);
+    if (l1s.length === 0) return;
+
+    const msgIndex = new Map<string, number>();
+    store.getAll().forEach((m, i) => msgIndex.set(m.id, i));
+
+    // Sort by (start position asc, span length desc) so at each starting
+    // point the LONGEST generation claims the ground first.
+    const sorted = [...l1s].sort((a, b) => {
+      const sa = msgIndex.get(a.sourceIds[0]) ?? Number.MAX_SAFE_INTEGER;
+      const sb = msgIndex.get(b.sourceIds[0]) ?? Number.MAX_SAFE_INTEGER;
+      return sa - sb || b.sourceIds.length - a.sourceIds.length;
+    });
+
+    const covered = new Set<string>();
+    let skippedStale = 0;
+    let skippedGhost = 0;
+    for (const s of sorted) {
+      // An L1 none of whose messages exist anymore can't own live ground.
+      if (!s.sourceIds.some(id => msgIndex.has(id))) { skippedGhost++; continue; }
+      // Fully-covered = stale generation / contained duplicate.
+      if (s.sourceIds.every(id => covered.has(id))) { skippedStale++; continue; }
+      for (const id of s.sourceIds) covered.add(id);
+      this.appendChunkRecord({
+        id: `c-${this.chunkIdCounter++}`,
+        sourceIds: [...s.sourceIds],
+        compressed: true,
+        summaryId: s.id,
+        ...(s.phaseType ? { phaseType: s.phaseType } : {}),
+      });
+    }
+    console.warn(
+      `[autobiographical] chunk-persistence migration: ${l1s.length} L1s → ` +
+      `${this.chunkRecords.length} records (${skippedStale} stale generations, ` +
+      `${skippedGhost} fully-orphaned L1s skipped)`,
+    );
+  }
+
+  /** Append a record to the chunks slot + in-memory mirror. */
+  protected appendChunkRecord(record: ChunkRecord): void {
+    this.chunkRecords.push(record);
+    this.store?.appendToStateJson(this.chunksStateId, record);
+  }
+
+  /**
+   * Mark a chunk's record compressed, linking its L1. Resolves the log slot
+   * by ID against the persisted array — never by in-memory index (see
+   * setMergedInto for the clobber this avoids).
+   */
+  protected markChunkRecordCompressed(recordId: string | undefined, summaryId: string): void {
+    if (!this.chunkPersistenceEnabled || !recordId) return;
+    const rec = this.chunkRecords.find(r => r.id === recordId);
+    if (!rec) return;
+    rec.compressed = true;
+    rec.summaryId = summaryId;
+    if (!this.store) return;
+    const stored = this.store.getStateJson(this.chunksStateId);
+    if (!Array.isArray(stored)) return;
+    const payload = Buffer.from(JSON.stringify(rec));
+    let found = false;
+    for (let i = 0; i < stored.length; i++) {
+      const item = stored[i] as ChunkRecord | null;
+      if (item && item.id === recordId) {
+        this.store.editStateItem(this.chunksStateId, i, payload);
+        found = true;
+      }
+    }
+    if (!found) {
+      console.warn(
+        `[autobiographical] markChunkRecordCompressed: ${recordId} not found in persisted chunk log`,
+      );
+    }
   }
 
   /**
@@ -504,6 +653,16 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         fullSnapshotEvery: 10,
       });
     } catch { /* already registered */ }
+    if (this.chunkPersistenceEnabled) {
+      try {
+        this.store.registerState({
+          id: this.chunksStateId,
+          strategy: 'append_log',
+          deltaSnapshotEvery: 50,
+          fullSnapshotEvery: 10,
+        });
+      } catch { /* already registered */ }
+    }
     try {
       this.store.registerState({
         id: this.counterStateId,
@@ -552,7 +711,22 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       this.mergeQueue = [];
       this.pins = [];
       this.pinIdCounter = 0;
+      this.chunkRecords = [];
+      this.chunkIdCounter = 0;
       return;
+    }
+
+    if (this.chunkPersistenceEnabled) {
+      const records = this.store.getStateJson(this.chunksStateId);
+      this.chunkRecords = (Array.isArray(records) ? (records as ChunkRecord[]) : [])
+        .filter(r => r && typeof r.id === 'string' && Array.isArray(r.sourceIds) && r.sourceIds.length > 0);
+      this.chunkIdCounter = this.chunkRecords.reduce((max, r) => {
+        const n = Number(r.id.replace(/^c-/, ''));
+        return Number.isFinite(n) && n >= max ? n + 1 : max;
+      }, 0);
+      this.chunkRecordsOrphaned = false;
+      this._orphanWarned = false;
+      this._overlapBlocked.clear();
     }
     const summaries = this.store.getStateJson(this.summariesStateId);
     const loaded = Array.isArray(summaries) ? (summaries as SummaryEntry[]) : [];
@@ -1566,6 +1740,33 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       throw new Error('No membrane instance for compression');
     }
 
+    // ---- Overlap guard (strict) ----
+    // With close-then-compress there is NO legitimate way for a chunk to
+    // overlap an existing L1's span. If it happens anyway (bookkeeping bug,
+    // store surgery gone wrong), refuse to produce: a warning in the log is
+    // strictly better than a duplicate memory in an agent's head.
+    const coveredByL1 = new Set<string>();
+    for (const s of this.summaries) {
+      if (s.level === 1 && Array.isArray(s.sourceIds)) {
+        for (const id of s.sourceIds) coveredByL1.add(id);
+      }
+    }
+    const overlapIds = chunk.messages.filter(m => coveredByL1.has(m.id)).map(m => m.id);
+    if (overlapIds.length > 0) {
+      const key = chunk.recordId ?? this.chunkKey(chunk);
+      if (!this._overlapBlocked.has(key)) {
+        this._overlapBlocked.add(key);
+        console.error(
+          `[autobiographical] OVERLAP GUARD: refusing to compress chunk ` +
+          `${chunk.recordId ?? `#${chunk.index}`} — ${overlapIds.length}/${chunk.messages.length} ` +
+          `of its messages are already covered by existing L1 summaries ` +
+          `(first: ${overlapIds[0]}). Duplicate-memory formation blocked; ` +
+          `investigate before resuming this span.`,
+        );
+      }
+      return;
+    }
+
     const targetTokens = this.config.summaryTargetTokens ?? 2000;
     const agentParticipant = this.config.summaryParticipant ?? 'Claude';
 
@@ -1606,6 +1807,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         this.pushSummary(stub);
         chunk.compressed = true;
         chunk.summaryId = stub.id;
+        this.markChunkRecordCompressed(chunk.recordId, stub.id);
         this._compressionCount++;
         logCompressionCall({
           operation: 'compress_l1',
@@ -1884,6 +2086,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       this.pushSummary(entry);
       chunk.compressed = true;
       chunk.summaryId = entry.id;
+      this.markChunkRecordCompressed(chunk.recordId, entry.id);
       this._compressionCount++;
       logSummaryId = entry.id;
 
@@ -3709,27 +3912,83 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   }
 
   /**
-   * Rebuild chunk boundaries based on current messages.
+   * Rebuild the chunk list: persisted records own the past; the running-sum
+   * chunker only extends at the frontier, and a chunk is only ever created
+   * once it CLOSES (reaches targetChunkTokens). The trailing partial chunk
+   * is never created and never compressed — eager partial-tail compression
+   * minted a new near-duplicate L1 per rebuild while the tail grew (the
+   * prefix-generation families found fleet-wide in the 2026-07 audit).
    */
   protected rebuildChunks(store: MessageStoreView): void {
-    const messagesToChunk = this.getCompressibleMessages(store);
-
-    // Preserve existing compressed chunks (legacy) and summary linkage (hierarchical)
-    const existingCompressed = new Map<string, Chunk>();
-    for (const chunk of this.chunks) {
-      if (chunk.compressed) {
-        const key = this.chunkKey(chunk);
-        existingCompressed.set(key, chunk);
-      }
-    }
-
-    // Rebuild chunks
     this.chunks = [];
     this.compressionQueue = [];
 
+    // ---- 1. Materialize persisted records (they OWN their messages). ----
+    const byId = new Map<string, StoredMessage>();
+    for (const m of store.getAll()) byId.set(m.id, m);
+
+    const consumed = new Set<string>();
+    let orphaned = 0;
+    for (const rec of this.chunkRecords) {
+      const msgs: StoredMessage[] = [];
+      for (const id of rec.sourceIds) {
+        const m = byId.get(id);
+        if (m) msgs.push(m);
+      }
+      if (msgs.length === 0) { orphaned++; continue; }
+      for (const m of msgs) consumed.add(m.id);
+      const chunk: Chunk = {
+        index: this.chunks.length,
+        startIndex: -1, // record-derived; filtered-array indices are not meaningful
+        endIndex: -1,
+        messages: msgs,
+        tokens: msgs.reduce((sum, m) => sum + (this.config.attachmentsIgnoreSize
+          ? this.estimateTextOnlyTokens(m)
+          : store.estimateTokens(m)), 0),
+        compressed: rec.compressed,
+        summaryId: rec.summaryId,
+        phaseType: rec.phaseType,
+        recordId: rec.id,
+      };
+      this.chunks.push(chunk);
+    }
+
+    // ---- 2. Fail closed on the chain-break signature. ----
+    // Most records resolving to zero live messages means message identity
+    // has been rebuilt/renumbered underneath us. Chunking "fresh" ground now
+    // would re-compress already-lived history into duplicate memories.
+    // Halt ALL compression until an operator reconciles the store.
+    if (this.chunkPersistenceEnabled && this.chunkRecords.length >= 3 &&
+        orphaned / this.chunkRecords.length > 0.5) {
+      this.chunkRecordsOrphaned = true;
+      this.compressionQueue = [];
+      if (!this._orphanWarned) {
+        this._orphanWarned = true;
+        console.error(
+          `[autobiographical] FAIL-CLOSED: ${orphaned}/${this.chunkRecords.length} chunk ` +
+          `records resolve to zero live messages (messages chain break / store ` +
+          `reconciliation signature). Compression halted to prevent duplicate ` +
+          `memory formation — reconcile the store before resuming.`,
+        );
+      }
+      return;
+    }
+    this.chunkRecordsOrphaned = false;
+
+    // Queue uncompressed record-backed chunks (crash-recovery: record was
+    // appended but the process died before its L1 landed).
+    for (const chunk of this.chunks) {
+      if (!chunk.compressed && !(chunk.recordId && this._overlapBlocked.has(chunk.recordId))) {
+        this.compressionQueue.push(chunk.index);
+      }
+    }
+
+    // ---- 3. Chunk the frontier: compressible messages not owned by any record. ----
+    const messagesToChunk = this.getCompressibleMessages(store)
+      .filter(m => !consumed.has(m.id));
+
     let currentChunk: StoredMessage[] = [];
     let currentTokens = 0;
-    // Track start position in the filtered array for chunk boundary metadata
     let chunkFilteredStart = 0;
 
     for (let i = 0; i < messagesToChunk.length; i++) {
@@ -3759,19 +4018,27 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       }
 
       if (shouldClose) {
-        const chunk = this.createChunk(
-          this.chunks.length,
-          chunkFilteredStart,
-          i + 1,
-          currentChunk,
-          currentTokens,
-          existingCompressed
-        );
-        this.chunks.push(chunk);
-
-        if (!chunk.compressed) {
-          this.compressionQueue.push(chunk.index);
+        const chunk: Chunk = {
+          index: this.chunks.length,
+          startIndex: chunkFilteredStart,
+          endIndex: i + 1,
+          messages: [...currentChunk],
+          tokens: currentTokens,
+          compressed: false,
+        };
+        // Persist the boundary the moment it closes — from here on this
+        // span is owned and never re-keyed by config drift or restarts.
+        if (this.chunkPersistenceEnabled) {
+          const record: ChunkRecord = {
+            id: `c-${this.chunkIdCounter++}`,
+            sourceIds: chunk.messages.map(m => m.id),
+            compressed: false,
+          };
+          this.appendChunkRecord(record);
+          chunk.recordId = record.id;
         }
+        this.chunks.push(chunk);
+        this.compressionQueue.push(chunk.index);
 
         currentChunk = [];
         currentTokens = 0;
@@ -3779,21 +4046,8 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       }
     }
 
-    if (currentChunk.length >= 4) {
-      const chunk = this.createChunk(
-        this.chunks.length,
-        chunkFilteredStart,
-        messagesToChunk.length,
-        currentChunk,
-        currentTokens,
-        existingCompressed
-      );
-      this.chunks.push(chunk);
-
-      if (!chunk.compressed) {
-        this.compressionQueue.push(chunk.index);
-      }
-    }
+    // NOTE: no trailing-partial chunk. An unclosed chunk is not a chunk —
+    // it compresses only after the running sum closes it.
   }
 
   /**

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -539,6 +539,15 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     // rebuild, so covered ground is owned and never re-compressed.
     this.migrateChunkRecords(ctx.messageStore);
     this.rebuildChunks(ctx.messageStore);
+    // Kick the merge ladder for pre-existing unmerged summaries. Normally a
+    // compression/merge completion does this, but a store that boots with a
+    // backlog above threshold and an empty queue (e.g. after a pyramid
+    // repair pruned duplicates and un-merged survivors) would otherwise
+    // never start consolidating. Idempotent: already-queued/merged sources
+    // are skipped.
+    if (this.config.hierarchical && !this.chunkRecordsOrphaned) {
+      this.checkMergeThreshold();
+    }
   }
 
   /**

--- a/src/strategies/knowledge.ts
+++ b/src/strategies/knowledge.ts
@@ -41,6 +41,17 @@ export class KnowledgeStrategy extends AutobiographicalStrategy {
   // Override: Semantic chunking
   // ============================================================================
 
+  /**
+   * KnowledgeStrategy keeps the legacy recompute-every-rebuild chunker:
+   * its chunk boundaries are semantic (phase transitions), recomputed from
+   * message content, and its stores are offline mining artifacts — the
+   * restart-duplication failure mode that chunk persistence fixes does not
+   * apply, and persisted token-sum records would fight the phase chunker.
+   */
+  protected get chunkPersistenceEnabled(): boolean {
+    return false;
+  }
+
   protected rebuildChunks(store: MessageStoreView): void {
     const messagesToChunk = this.getCompressibleMessages(store);
 

--- a/test/chunk-persistence.test.ts
+++ b/test/chunk-persistence.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Regression tests for chunk-boundary persistence + close-then-compress.
+ *
+ * Background (Mythos duplication incident, 2026-07; fleet audit):
+ *   1. Chunk boundaries were recomputed from a running token sum on every
+ *      rebuild; "already compressed" was recovered only by EXACT
+ *      message-ID-set match against persisted L1 sourceIds. Any boundary
+ *      shift (config change, restart, message mutation, chain break)
+ *      re-keyed the tail → mass duplicate L1s over already-lived ground.
+ *   2. The trailing PARTIAL chunk (>=4 messages, under targetChunkTokens)
+ *      was compressed eagerly on every rebuild while it grew → families of
+ *      prefix-generation L1s (same start, growing span), all retained, all
+ *      merged upward into the same L2 (content multiplication).
+ *
+ * New contract pinned here:
+ *   - A chunk is compressed only after it CLOSES (running sum reaches
+ *     targetChunkTokens); the trailing partial chunk is never compressed.
+ *   - Closing a chunk persists a ChunkRecord to the `autobio:chunks`
+ *     chronicle state slot; persisted records OWN the past — rebuilds and
+ *     restarts never re-chunk covered ground, regardless of config drift.
+ *   - L1 production refuses to overlap an existing L1 (strict guard).
+ *   - If most records resolve to zero live messages (chain-break
+ *     signature), compression fails CLOSED (no re-chunking of history).
+ *   - Stores from before this change migrate lazily: records are
+ *     synthesized from existing L1 sourceIds, longest generation per
+ *     prefix family.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const BASE = './test-chunk-persistence';
+let storeSeq = 0;
+function freshPath(): string {
+  return `${BASE}-${storeSeq++}`;
+}
+function cleanup() {
+  for (let i = 0; i < storeSeq + 1; i++) {
+    const p = `${BASE}-${i}`;
+    if (existsSync(p)) rmSync(p, { recursive: true, force: true });
+  }
+}
+
+const SUMS = 'default/autobio:summaries';
+const CHUNKS = 'default/autobio:chunks';
+
+interface ApiMessage { participant: string; content: ContentBlock[] }
+
+function mockMembrane() {
+  const calls: Array<{ messages: ApiMessage[] }> = [];
+  return {
+    calls,
+    membrane: {
+      complete: async (request: { messages: ApiMessage[] }) => {
+        calls.push({ messages: request.messages });
+        const inputChars = request.messages
+          .flatMap((m) => m.content)
+          .map((b) => (b as { text?: string }).text ?? '')
+          .join('').length;
+        const text = `[mock summary inChars=${inputChars}] ` + 'x '.repeat(40);
+        return {
+          content: [{ type: 'text', text }],
+          usage: { input_tokens: Math.ceil(inputChars / 4), output_tokens: 25 },
+        };
+      },
+    } as any,
+  };
+}
+
+const t = (s: string): ContentBlock => ({ type: 'text', text: s });
+
+async function drain(manager: ContextManager): Promise<void> {
+  for (let i = 0; i < 500; i++) {
+    if (manager.isReady()) return;
+    await manager.tick();
+  }
+  throw new Error('drain: queue did not converge within 500 ticks');
+}
+
+function l1s(manager: ContextManager): Array<{ id: string; sourceIds: string[] }> {
+  const stored = manager.getStore().getStateJson(SUMS);
+  return (Array.isArray(stored) ? stored : []).filter(
+    (s: any) => s && s.level === 1,
+  );
+}
+
+function assertDisjointL1s(entries: Array<{ id: string; sourceIds: string[] }>) {
+  const seen = new Map<string, string>();
+  for (const s of entries) {
+    for (const mid of s.sourceIds ?? []) {
+      const prev = seen.get(mid);
+      assert.ok(
+        prev === undefined || prev === s.id,
+        `message ${mid} covered by both ${prev} and ${s.id} — duplicate L1s over the same span`,
+      );
+      seen.set(mid, s.id);
+    }
+  }
+}
+
+/** ~10 tokens of text per message at estimateTokens' chars/4 heuristic. */
+const filler = (i: number) => `message ${i} ` + 'word '.repeat(8);
+
+describe('Chunk persistence: close-then-compress', () => {
+  before(() => cleanup());
+  after(() => cleanup());
+
+  it('never compresses an unclosed (trailing partial) chunk', async () => {
+    const path = freshPath();
+    const { membrane, calls } = mockMembrane();
+    const strategy = new AutobiographicalStrategy({
+      targetChunkTokens: 1000, // far above what 6 tiny messages reach
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({ path, strategy, membrane });
+
+    for (let i = 0; i < 6; i++) manager.addMessage(i % 2 ? 'agent' : 'user', [t(filler(i))]);
+    await drain(manager);
+
+    assert.strictEqual(
+      calls.length,
+      0,
+      'partial tail chunk (under targetChunkTokens) must not be compressed',
+    );
+    assert.strictEqual(l1s(manager).length, 0);
+    await manager.close();
+  });
+
+  it('a growing tail never produces prefix-generation L1 families', async () => {
+    const path = freshPath();
+    const { membrane } = mockMembrane();
+    const strategy = new AutobiographicalStrategy({
+      targetChunkTokens: 120,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({ path, strategy, membrane });
+
+    // Grow in small increments with a full drain between each — the exact
+    // pattern that used to mint one L1 generation per drain.
+    for (let batch = 0; batch < 12; batch++) {
+      for (let i = 0; i < 4; i++) {
+        manager.addMessage(i % 2 ? 'agent' : 'user', [t(filler(batch * 4 + i))]);
+      }
+      await drain(manager);
+    }
+
+    const entries = l1s(manager);
+    assert.ok(entries.length > 0, 'expected some closed chunks to compress');
+    assertDisjointL1s(entries);
+    // No two L1s may share a starting message (prefix-family signature).
+    const starts = entries.map((s) => s.sourceIds[0]);
+    assert.strictEqual(
+      new Set(starts).size,
+      starts.length,
+      'two L1s share a starting message — prefix-generation family detected',
+    );
+    await manager.close();
+  });
+
+  it('persists chunk records when chunks close', async () => {
+    const path = freshPath();
+    const { membrane } = mockMembrane();
+    const strategy = new AutobiographicalStrategy({
+      targetChunkTokens: 100,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({ path, strategy, membrane });
+    for (let i = 0; i < 40; i++) manager.addMessage(i % 2 ? 'agent' : 'user', [t(filler(i))]);
+    await drain(manager);
+
+    const records = manager.getStore().getStateJson(CHUNKS) as any[];
+    assert.ok(Array.isArray(records) && records.length > 0, 'chunk records persisted');
+    for (const r of records) {
+      assert.ok(typeof r.id === 'string' && r.id.length > 0);
+      assert.ok(Array.isArray(r.sourceIds) && r.sourceIds.length >= 4);
+      assert.strictEqual(r.compressed, true, `record ${r.id} compressed after drain`);
+      assert.ok(typeof r.summaryId === 'string', `record ${r.id} linked to its L1`);
+    }
+    const l1 = l1s(manager);
+    assert.strictEqual(records.length, l1.length, 'one record per L1');
+    await manager.close();
+  });
+
+  it('restart + config drift does not re-compress covered ground', async () => {
+    const path = freshPath();
+    const { membrane } = mockMembrane();
+    {
+      const strategy = new AutobiographicalStrategy({
+        targetChunkTokens: 100,
+        headWindowTokens: 0,
+        recentWindowTokens: 0,
+        hierarchical: true,
+      });
+      const manager = await ContextManager.open({ path, strategy, membrane });
+      for (let i = 0; i < 60; i++) manager.addMessage(i % 2 ? 'agent' : 'user', [t(filler(i))]);
+      await drain(manager);
+      assert.ok(l1s(manager).length >= 3, 'seed store built several L1s');
+      await manager.close();
+    }
+
+    // Restart with SHIFTED boundary inputs — the pre-fix code re-keys every
+    // chunk (exact sourceIds match fails) and re-compresses all of history.
+    const fresh = mockMembrane();
+    const strategy = new AutobiographicalStrategy({
+      targetChunkTokens: 170, // drifted
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({
+      path,
+      strategy,
+      membrane: fresh.membrane,
+    });
+    await drain(manager);
+
+    const entries = l1s(manager);
+    assertDisjointL1s(entries);
+    assert.strictEqual(
+      fresh.calls.length,
+      0,
+      `restart with drifted config re-compressed covered ground (${fresh.calls.length} calls)`,
+    );
+    await manager.close();
+  });
+
+  it('fails closed when chunk records mass-orphan (chain-break signature)', async () => {
+    const path = freshPath();
+    const { membrane, calls } = mockMembrane();
+    // Seed: chunk records referencing message ids that do NOT exist (as after
+    // a messages chain break / renumbering), while live messages are present.
+    {
+      const strategy = new AutobiographicalStrategy({ recentWindowTokens: 1000 });
+      const manager = await ContextManager.open({ path, strategy, membrane });
+      const store = manager.getStore();
+      try {
+        store.registerState({ id: CHUNKS, strategy: 'append_log', deltaSnapshotEvery: 50, fullSnapshotEvery: 10 });
+      } catch { /* registered by strategy already */ }
+      for (let c = 0; c < 4; c++) {
+        store.appendToStateJson(CHUNKS, {
+          id: `c-${c}`,
+          sourceIds: [`ghost-${c}-a`, `ghost-${c}-b`, `ghost-${c}-c`, `ghost-${c}-d`],
+          compressed: true,
+          summaryId: `L1-${c}`,
+        });
+      }
+      manager.sync();
+      await manager.close();
+    }
+
+    const strategy = new AutobiographicalStrategy({
+      targetChunkTokens: 100,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({ path, strategy, membrane });
+    for (let i = 0; i < 60; i++) manager.addMessage(i % 2 ? 'agent' : 'user', [t(filler(i))]);
+    await drain(manager);
+
+    assert.strictEqual(
+      calls.length,
+      0,
+      'mass-orphaned records must fail closed: no compression until an operator looks',
+    );
+    assert.strictEqual(l1s(manager).length, 0);
+    await manager.close();
+  });
+
+  it('migrates legacy stores: synthesizes records, collapses prefix families, no recompression', async () => {
+    const path = freshPath();
+    const { membrane, calls } = mockMembrane();
+    // Seed a LEGACY store: messages + L1 summaries, NO chunks slot.
+    // Includes a prefix family (L1-1 ⊂ L1-2) from the old partial-tail bug.
+    {
+      const strategy = new AutobiographicalStrategy({ recentWindowTokens: 100000 });
+      const manager = await ContextManager.open({ path, strategy, membrane });
+      const store = manager.getStore();
+      const ids: string[] = [];
+      for (let i = 0; i < 16; i++) {
+        const m = manager.addMessage(i % 2 ? 'agent' : 'user', [t(filler(i))]);
+        ids.push((m as any).id ?? String(i));
+      }
+      const mk = (id: string, src: string[], extra: Record<string, unknown> = {}) => ({
+        id,
+        level: 1,
+        content: `memory ${id}`,
+        tokens: 10,
+        sourceLevel: 0,
+        sourceIds: src,
+        sourceRange: { first: src[0], last: src[src.length - 1] },
+        created: 1750000000000,
+        ...extra,
+      });
+      store.appendToStateJson(SUMS, mk('L1-0', ids.slice(0, 6)));
+      store.appendToStateJson(SUMS, mk('L1-1', ids.slice(6, 10)));  // stale generation
+      store.appendToStateJson(SUMS, mk('L1-2', ids.slice(6, 14)));  // superset, same start
+      manager.sync();
+      await manager.close();
+    }
+
+    const strategy = new AutobiographicalStrategy({
+      targetChunkTokens: 100,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({ path, strategy, membrane });
+    await drain(manager);
+
+    const records = manager.getStore().getStateJson(CHUNKS) as any[];
+    assert.ok(Array.isArray(records), 'migration created the chunks slot');
+    const bySummary = new Map(records.map((r: any) => [r.summaryId, r]));
+    assert.ok(bySummary.has('L1-0'), 'record synthesized for L1-0');
+    assert.ok(bySummary.has('L1-2'), 'record synthesized for longest generation L1-2');
+    assert.ok(!bySummary.has('L1-1'), 'stale prefix generation L1-1 gets NO record');
+    // Covered ground must not be re-compressed; only the uncovered tail
+    // (ids[14..15], 2 messages — under min chunk length) may ever compress,
+    // and it cannot close here, so: zero calls.
+    assert.strictEqual(calls.length, 0, 'migration must not trigger recompression');
+    await manager.close();
+  });
+});


### PR DESCRIPTION
## Problem

Two duplicate-L1 generators, live since the strategy shipped (2026-07 fleet audit found contaminated merge pyramids in every production store; surfaced by Mythos self-reporting duplication in his own context):

1. **Boundary re-keying** — chunk boundaries were recomputed from a running token sum on every rebuild, and "already compressed" was recovered only by exact message-ID-set equality against persisted L1 `sourceIds`. Any boundary-input shift (config drift, head-window re-derivation, token re-estimates, message mutations, messages chain breaks) re-keyed the whole tail and re-compressed already-summarized history into duplicate L1s. Production signature: re-consolidation storms minutes after each restart.

2. **Partial-tail compression** — the trailing unclosed chunk (>=4 msgs, under `targetChunkTokens`) was created and queued on every rebuild while it grew, minting prefix-generation L1 families (same start, growing span). Nothing superseded stale generations: they stayed on the unmerged frontier, rendered, and merged upward together — near-identical narratives multiplied into the same L2. `maxSpeculativeL1s` rate-limited this generator without fixing it.

## Fix

- **New `autobio:chunks` chronicle state slot** (append_log, branch-aware): one `ChunkRecord` per **closed** chunk, membership by message ID. Records own the past; `rebuildChunks` materializes chunks from records and runs the running-sum chunker only on unowned (frontier) messages. Lifecycle: close → persist record → compress → mark record by id (never by index).
- **No trailing-partial compression.** A chunk compresses only after it closes. Config knobs now affect only future chunks, by construction.
- **Strict overlap guard** at L1 production: producing an L1 over messages already covered by an existing L1 is refused + logged instead of written.
- **Fail-closed on mass record orphaning** (>50% of records resolving to zero live messages = messages chain-break signature): compression halts loudly rather than re-chunking history into duplicates.
- **Lazy migration** for legacy stores: records synthesized from existing L1 `sourceIds` (longest generation per starting point); runs once per store on first boot.
- `initialize()` kicks `checkMergeThreshold` once (post-repair stores boot with an above-threshold unmerged backlog and an empty queue).
- `KnowledgeStrategy` opts out (`chunkPersistenceEnabled=false`) — its semantic phase chunker recomputes boundaries from content by design.
- `scripts/repair-pyramid.ts` — offline repair for contaminated stores: keeps one L1 per span, prunes stale generations, wipes L2/L3s whose prose was merged from duplicates, un-merges survivors for regeneration. Dry-run by default; snapshot writes keep full pre-repair history in the record log.

## Validation

- 6 new regression tests (`test/chunk-persistence.test.ts`), all fail pre-fix; full suite **178/178**.
- Shadow-run on a copy of the Mythos production store: migration `175 L1s → 65 records (110 stale generations skipped)`; reopen with drifted `targetChunkTokens` → records stable, zero recompression.
- Repair + mock drain on the same copy: 27/28 L2s + 4/4 L3s wiped, drain converged in 10 merges, post-repair audit: 0 contaminated L2/L3s, 0 prefix families, overlapping source refs 1068 → 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)