### PR TITLE
productionBudgetTokens: standing production target for KV-gentle budget descent

### DIFF
--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -2956,6 +2956,35 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       this.handleProducedOps(result.produced);
     }
 
+    // Standing production target (productionBudgetTokens): run a SHADOW pick
+    // against the production budget on copies of the same inputs. Pure CPU,
+    // no LLM, no state commit - only its produce ops are enqueued, so the
+    // drain keeps the forest deep enough to lower the live budget to this
+    // level at any time without a fold-storm or an OverBudget dead end.
+    const prodBudget = this.config.productionBudgetTokens;
+    if (prodBudget !== undefined && prodBudget < totalBudget) {
+      try {
+        const shadowInputs: PickerInputs = {
+          ...pickerInputs,
+          chunks: pickerChunks.map((c) => ({ ...c })),
+        };
+        const shadowResult = this.buildPicker(shadowInputs).run(shadowInputs, {
+          totalBudget: prodBudget,
+          targetBudget: prodBudget * (1 - slack),
+          slack,
+        });
+        if (shadowResult.produced.length > 0) {
+          this.handleProducedOps(shadowResult.produced);
+        }
+      } catch (err) {
+        // A failing shadow pick (incl. its own OverBudget) must never break
+        // the live compile; production simply has not converged yet.
+        if (!(err instanceof OverBudgetError)) {
+          console.warn("autobio: shadow production pick failed:", err);
+        }
+      }
+    }
+
     // Hard-fail check: if the picker exhausted itself but the final render
     // would still exceed the HARD budget (not just the soft target), surface
     // an OverBudgetError to the host rather than silently dropping entries.

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -532,6 +532,19 @@ export interface AutobiographicalConfig {
    * (no picker request needed). Default true when adaptiveResolution is on.
    */
   speculativeProduction?: boolean;
+
+  /**
+   * Standing production target (tokens): keep the summary forest deep enough
+   * that a compile would fit under THIS budget, even while the live compile
+   * budget is higher. Enables lowering the live budget at any later moment
+   * with zero fold-storm and a single KV invalidation ("produce first, fold
+   * once"), and makes an OverBudget hard-fail on the way down structurally
+   * unreachable: by the time the budget drops, every fold the picker will ask
+   * for already exists. Produced-but-unused summaries are cheap storage;
+   * production LLM calls run through the normal drain queues and are visible
+   * in the usual logs. No effect unless lower than the live compile budget.
+   */
+  productionBudgetTokens?: number;
 }
 
 /**


### PR DESCRIPTION
Implements the "produce compression for a budget" design: a standing target that keeps the summary forest deep enough to fit a *lower* budget than the live one, so the live budget can be dropped at any later moment in one move.

## Mechanism
After the real picker run in `selectAdaptive`, run a **shadow pick** against `productionBudgetTokens` on copies of the same inputs — pure CPU, no LLM, no state commit; only its produce ops are enqueued into the normal drain queues. Produced-but-unused summaries are cheap storage; production LLM calls are visible in the usual logs.

## Why
Naive descent (just lower the budget) fails two ways:
1. the picker demands folds that don't exist yet → `OverBudgetError` → with the current drain scheduling, a hard-down deadlock (see anima-research/agent-framework#58 for the breaker + field data);
2. each incremental step rebuilds the prefix → one full KV-cache invalidation per step.

With a standing target: zero fold-storm at switch time (every fold already exists), a single KV invalidation for the whole descent ("produce first, fold once"), and OverBudget on the way down becomes structurally unreachable.

## Field verification (2026-07-10, resident agent)
- Target set while live budget stayed high; forest converged ambient.
- Descent executed in one restart: ~658K → ~364K real input tokens, first compile clean, wake cost halved.

## Notes
- No effect unless the target is lower than the live compile budget (guarded).
- A failing shadow pick (incl. its own OverBudget while production hasn't converged) never breaks the live compile.
- `bun test`: failure count identical to main baseline (6), no new failures.
- Companion recipe passthrough: anima-research/connectome-host PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)