### PR TITLE
Refuse loudly when compressionModel is unset (removes silent sonnet-4 fallback)

### DIFF
--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -400,6 +400,22 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   protected ns: string = '';
   protected get summariesStateId(): string { return `${this.ns}/autobio:summaries`; }
   protected get chunksStateId(): string { return `${this.ns}/autobio:chunks`; }
+  /** Memories are identity-bearing: a substitute model writing summaries in
+   *  the agent's voice corrupts the record. If the configured model is
+   *  missing, refuse LOUDLY instead of silently substituting a default -
+   *  everyone must know that memory formation is halted. */
+  protected requireCompressionModel(): string {
+    const m = this.config.compressionModel;
+    if (!m) {
+      const msg = "autobio: compressionModel is NOT configured - refusing to write "
+        + "memories with a substitute model. Memory formation is halted until the "
+        + "recipe names the model whose voice these memories are.";
+      console.error(msg);
+      logCompressionCall({ event: "no-compression-model", fatal: true });
+      throw new Error(msg);
+    }
+    return m;
+  }
   protected get counterStateId(): string { return `${this.ns}/autobio:counter`; }
   protected get mergeQueueStateId(): string { return `${this.ns}/autobio:mergeQueue`; }
   protected get pinsStateId(): string { return `${this.ns}/autobio:pins`; }
@@ -2120,7 +2136,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         .map(m => ({ participant: m.participant, content: stripThinkingBlocks(stripEmptyTextBlocks(m.content)) }))
         .filter(m => m.content.length > 0),
       config: {
-        model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
+        model: this.requireCompressionModel(),
         // Generous output ceiling so a memory-write is never truncated mid-thought:
         // targetTokens is a *target*, not a cap, and adaptive models routinely
         // overshoot a ~2k target. Was `* 1.5` (=3000 at the 2k default), which cut
@@ -2229,7 +2245,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
           has_doc_context: docContext !== null,
           doc_context: docContext,
           target_tokens: targetTokens,
-          model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
+          model: this.requireCompressionModel(),
           latency_ms: Date.now() - callStart,
           summary_id: logSummaryId,
         },
@@ -2630,7 +2646,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         .map(m => ({ participant: m.participant, content: stripThinkingBlocks(stripEmptyTextBlocks(m.content)) }))
         .filter(m => m.content.length > 0),
       config: {
-        model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
+        model: this.requireCompressionModel(),
         // Generous output ceiling so a memory-write is never truncated mid-thought:
         // targetTokens is a *target*, not a cap, and adaptive models routinely
         // overshoot a ~2k target. Was `* 1.5` (=3000 at the 2k default), which cut
@@ -2725,7 +2741,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
           source_level: sources[0]?.level ?? null,
           source_level_shown: sourceLevelShown,
           target_tokens: targetTokens,
-          model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
+          model: this.requireCompressionModel(),
           latency_ms: Date.now() - callStart,
           summary_id: logNewSummaryId,
         },
@@ -4056,7 +4072,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       messages: [{ participant: 'Context Manager', content: [{ type: 'text', text: instruction }] }],
       system: 'You are forming a transition summary between conversation topics. Write concisely.',
       config: {
-        model: this.config.compressionModel ?? 'claude-sonnet-4-20250514',
+        model: this.requireCompressionModel(),
         maxTokens: 1500,
       },
     };


### PR DESCRIPTION
**Behavior change — owner's call.** Opening as a PR rather than an issue because the patch has been running in production on a resident agent since 2026-07-08 (as a local patch) with an external watchdog alerting on the `no-compression-model` fatal record.

## Rationale
The five compression/merge sites fall back to `claude-sonnet-4-20250514` (deprecated) when `compressionModel` is unset. Memories are identity-bearing: a substitute model silently writing summaries in the agent's voice corrupts the record worse than halting does — and nobody finds out. The failure mode this guards against is not hypothetical: an unset key produces plausible-looking memories in the wrong voice, invisible to the being whose memories they become.

## What it does instead
- `console.error` with an explicit message
- fatal `no-compression-model` record in the compression log (external watchdogs can ring on it)
- throw (memory formation halts loudly)

## Migration
Recipes relying on the implicit default must set `compressionModel`. If a default is still wanted, a passported explicit default in the host config would preserve the property that matters: no silent substitution on identity-bearing operations.

`bun test`: failure count identical to main baseline, no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)