### PR TITLE
release context-manager 0.5.10

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 
@@ -49,10 +49,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           # node 24 ships npm >= 11.5.1, required for OIDC publishing.
           node-version: 24

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@animalabs/context-manager",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@animalabs/context-manager",
-      "version": "0.5.9",
+      "version": "0.5.10",
       "license": "MIT",
       "dependencies": {
         "@animalabs/chronicle": "^0.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@animalabs/context-manager",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "description": "Context management layer for LLM-based agents using Chronicle and Membrane",
   "type": "module",
   "main": "dist/src/index.js",


### PR DESCRIPTION
## What changed

Bumps context-manager to 0.5.10, synchronizes lock metadata, and moves the release workflow to current GitHub actions on Node 24/npm 11.

## Why

Publish the connectome-host stack through npm trusted publishing with reproducible registry dependencies.

## Validation

Type-check; build; npm test (200 passing, 4 todo)