### PR TITLE
Two fixes from the 2026-07-25 mythos outage: kv-stable fold-walk oscillation + quadratic ingest

### DIFF
--- a/src/adaptive/strategies/kv-stable.ts
+++ b/src/adaptive/strategies/kv-stable.ts
@@ -58,6 +58,9 @@ export class KvStableStrategy implements FoldingStrategy {
   private readonly fPrev: Map<ChunkId, number>;
   private target: Map<ChunkId, number> | null = null;
   private _lastPlan: ControlPlan | null = null;
+  /** Cycle guard (2026-07-25): counts per emitted op key — see nextOp. */
+  private readonly opEmits = new Map<string, number>();
+  private cycleWarned = false;
 
   constructor(inputs: PickerInputs, opts: KvStableOptions = {}) {
     this.inputs = inputs;
@@ -166,14 +169,44 @@ export class KvStableStrategy implements FoldingStrategy {
       const tgt = target.get(c.id) ?? 0;
       if (cur === tgt) continue;
 
+      let op: FoldOp;
       if (cur < tgt) {
         const summary = c.ancestorAt(tgt);
         if (!summary) continue; // unrealizable target (summary not produced) — skip
-        return { kind: 'raise', groupRoot: summary.id };
+        op = { kind: 'raise', groupRoot: summary.id };
+      } else {
+        const summary = c.ancestorAt(cur);
+        if (!summary) continue;
+        op = { kind: 'lower', groupRoot: summary.id };
       }
-      const summary = c.ancestorAt(cur);
-      if (!summary) continue;
-      return { kind: 'lower', groupRoot: summary.id };
+
+      // Cycle guard (2026-07-25, mythos wedge): raise/lower act on a whole
+      // GROUP root while targets are per-chunk. When a group's leaves carry
+      // mixed targets — possible when chunk ownership and the summary tree
+      // disagree after store surgery ("head boundary disagrees with chunk
+      // ownership") — the walk oscillates on the same root forever: raising
+      // for one leaf overshoots its siblings, lowering for a sibling undoes
+      // the raise. The picker's iteration bound is 10×chunks with O(chunks)
+      // per step, so a live agent burns hours of CPU per compile. Emitting
+      // the same op more than 8 times means we are cycling, not walking:
+      // treat the chunk as unrealizable, warn once, and move on. The
+      // frontier stays renderable — merely at the nearest realizable cut.
+      const key = `${op.kind}:${String(op.groupRoot)}`;
+      const n = (this.opEmits.get(key) ?? 0) + 1;
+      if (n > 8) {
+        if (!this.cycleWarned) {
+          this.cycleWarned = true;
+          console.error(
+            `[kv-stable] non-converging fold walk: op ${key} emitted >8 times — ` +
+              `target frontier cuts through a group (ownership drift after store ` +
+              `surgery?). Skipping oscillating chunks; window renders at the ` +
+              `nearest realizable frontier.`,
+          );
+        }
+        continue;
+      }
+      this.opEmits.set(key, n);
+      return op;
     }
     return null;
   }

--- a/src/message-store.ts
+++ b/src/message-store.ts
@@ -228,6 +228,35 @@ export class MessageStore {
       ...(extra ?? {}),
     };
 
+    // Write-through: keep the materialized cache hot across appends.
+    // Ingest-time rebuilds (rebuildChunks in the autobiographical strategy)
+    // call getAll() on every new message; without write-through each append
+    // invalidates the cache and forces a full state-slot re-materialization
+    // — quadratic ingest (2026-07-25 mythos "wedge": ~10s/message at 13.5k
+    // messages, event loop starved for hours by ambient traffic + backfill).
+    //
+    // The cached entry MUST be the chronicle round-trip (serde) form, not a
+    // hand-built object: serde reorders keys and drops undefined fields, and
+    // downstream request hashing stringifies message content — a shape that
+    // differs between a warm cache and a fresh rebuild breaks hash-keyed
+    // dedup (compression in-flight registry, quarantine keys). Fetch the
+    // just-written record back through the point lookup; on chronicle
+    // versions without it, fall back to plain invalidation (old behavior).
+    const canPointLookup =
+      typeof (this.store as { getStateItemJson?: unknown }).getStateItemJson === 'function';
+    const canonical = canPointLookup ? this.getInternal(index) : null;
+    if (
+      canonical &&
+      this.allCache &&
+      this.allCache.branch === this.store.currentBranch().name &&
+      this.allCache.internals.length === index
+    ) {
+      this.allCache.internals.push(canonical);
+      this.allCache.sequence = this.store.currentSequence();
+    } else {
+      this.allCache = null;
+    }
+
     this.idToIndex.set(message.id, index);
     this.emit({ type: 'add', message });
     return message;
@@ -270,6 +299,24 @@ export class MessageStore {
 
     this.store.editStateItem(this.stateId, index, Buffer.from(JSON.stringify(updated)));
 
+    // Write-through the materialized cache (see append — the cached entry
+    // must be the chronicle round-trip form, so re-fetch it canonically).
+    const canonicalEdit =
+      typeof (this.store as { getStateItemJson?: unknown }).getStateItemJson === 'function'
+        ? this.getInternal(index)
+        : null;
+    if (
+      canonicalEdit &&
+      this.allCache &&
+      this.allCache.branch === this.store.currentBranch().name &&
+      this.allCache.internals[index]
+    ) {
+      this.allCache.internals[index] = canonicalEdit;
+      this.allCache.sequence = this.store.currentSequence();
+    } else {
+      this.allCache = null;
+    }
+
     this.emit({ type: 'edit', messageId, oldContent, newContent });
   }
 
@@ -296,6 +343,18 @@ export class MessageStore {
     }
 
     this.store.redactStateItems(this.stateId, index, index + 1);
+    // Write-through the materialized cache (see append); fall back to
+    // invalidation if the cache wasn't current.
+    if (
+      this.allCache &&
+      this.allCache.branch === this.store.currentBranch().name &&
+      this.allCache.internals.length === this.length() + 1
+    ) {
+      this.allCache.internals.splice(index, 1);
+      this.allCache.sequence = this.store.currentSequence();
+    } else {
+      this.allCache = null;
+    }
     this.rebuildIndex();
 
     this.emit({ type: 'remove', messageId });
@@ -316,6 +375,7 @@ export class MessageStore {
       // Not sharded — defer to normal remove path (re-look up via getInternal
       // since the normal `remove` checks bodyGroupId).
       this.store.redactStateItems(this.stateId, index, index + 1);
+      this.allCache = null; // rare path: plain invalidation
       this.rebuildIndex();
       this.emit({ type: 'remove', messageId });
       return;
@@ -332,6 +392,7 @@ export class MessageStore {
     const firstId = all[from].id;
     const lastId = all[to].id;
     this.store.redactStateItems(this.stateId, from, to + 1);
+    this.allCache = null; // rare path: plain invalidation
     this.rebuildIndex();
     this.emit({ type: 'removeRange', fromId: firstId, toId: lastId });
   }
@@ -370,6 +431,7 @@ export class MessageStore {
     }
 
     this.store.redactStateItems(this.stateId, fromIndex, toIndex + 1);
+    this.allCache = null; // rare path: plain invalidation
     this.rebuildIndex();
 
     this.emit({ type: 'removeRange', fromId, toId });
@@ -729,12 +791,42 @@ export class MessageStore {
   private getAllInternal(): StoredMessageInternal[] {
     const branch = this.store.currentBranch().name;
     const sequence = this.store.currentSequence();
-    if (
-      this.allCache &&
-      this.allCache.sequence === sequence &&
-      this.allCache.branch === branch
-    ) {
-      return this.allCache.internals;
+    if (this.allCache && this.allCache.branch === branch) {
+      if (this.allCache.sequence === sequence) {
+        return this.allCache.internals;
+      }
+      // The store-global sequence moved, but that may be writes to OTHER
+      // state slots (summaries, autobio resolutions, framework/state, …).
+      // All in-process mutations of THIS state flow through the mutators
+      // above, which write through or invalidate the cache explicitly — so
+      // if the messages slot still has the same item count and the same
+      // last record id, the cached array is current: re-stamp, don't
+      // re-materialize. (A full re-materialization here on every foreign
+      // append made ingest quadratic — 2026-07-25 mythos wedge.)
+      // Feature-detect getStateItemJson (chronicle >= 0.2.2): the fallback
+      // inside getInternal() is getAllInternal() itself — calling it here
+      // on an older chronicle would recurse. No point lookup → no cheap
+      // revalidation → keep the old full-rebuild behavior.
+      const canPointLookup =
+        typeof (this.store as { getStateItemJson?: unknown }).getStateItemJson === 'function';
+      const count = canPointLookup ? this.length() : -1;
+      if (count === this.allCache.internals.length) {
+        if (count === 0) {
+          this.allCache.sequence = sequence;
+          return this.allCache.internals;
+        }
+        const lastCached = this.allCache.internals[count - 1];
+        const lastLive = this.getInternal(count - 1);
+        if (
+          lastCached &&
+          lastLive &&
+          lastLive.id === lastCached.id &&
+          lastLive.sequence === lastCached.sequence
+        ) {
+          this.allCache.sequence = sequence;
+          return this.allCache.internals;
+        }
+      }
     }
     const state = this.store.getStateJson(this.stateId);
     const internals =

--- a/test/adaptive/kv-cycle-guard.test.ts
+++ b/test/adaptive/kv-cycle-guard.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Regression test for the kv-stable fold-walk oscillation (2026-07-25).
+ *
+ * `nextOp` emits raise/lower ops against a whole GROUP root while the solved
+ * target frontier is per-chunk. A group whose leaves carry MIXED targets —
+ * which can happen when chunk ownership and the summary tree disagree after
+ * store surgery / branch rollback ("head boundary disagrees with chunk
+ * ownership") — made the walk ping-pong on the same root forever: raising
+ * the group for one leaf overshot its siblings, lowering it for a sibling
+ * undid the raise. The picker's iteration bound is max(1000, 10×chunks)
+ * with O(chunks) work per step, so a live agent burned hours of CPU on
+ * every compile (the mythos wedge: event loop starved, agent down).
+ *
+ * The fix is a cycle guard in KvStableStrategy.nextOp: the same op key
+ * emitted more than 8 times means the walk is cycling, not converging —
+ * the chunk is treated as unrealizable and skipped, and the frontier
+ * renders at the nearest realizable cut.
+ *
+ * These tests inject a mixed-target frontier directly (white-box, via the
+ * private `target` field) because a group-inconsistent plan is precisely
+ * the corrupted-state condition that `solve()` is supposed to never
+ * produce — the guard exists for when reality disagrees.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { Picker } from '../../src/adaptive/picker.js';
+import type { FoldingBudget, ChunkId } from '../../src/adaptive/folding-strategy.js';
+import type { PickerInputs } from '../../src/adaptive/picker.js';
+import { SummaryTree } from '../../src/adaptive/summary-tree.js';
+import { KvStableStrategy } from '../../src/adaptive/strategies/kv-stable.js';
+import { buildChronicleWithChain } from './harness.js';
+
+const BUDGET = (totalBudget: number, slack = 0.1): FoldingBudget => ({
+  totalBudget,
+  targetBudget: totalBudget * (1 - slack),
+  slack,
+});
+
+function inputsOf(ch: ReturnType<typeof buildChronicleWithChain>): PickerInputs {
+  return {
+    chunks: ch.chunks,
+    summaries: ch.summaries,
+    recallPairTokens: ch.recallPairTokens,
+    headTokens: 0,
+    tailTokens: 0,
+    headChunkIds: new Set(),
+    tailChunkIds: new Set(),
+  };
+}
+
+/** Build a strategy whose solved target cuts through one L1 group:
+ *  the group's first leaf targets L1 while its siblings target raw. */
+function strategyWithMixedTargetGroup(inputs: PickerInputs): {
+  strategy: KvStableStrategy;
+  groupLeafIds: ChunkId[];
+} {
+  const tree = new SummaryTree(inputs);
+  const strategy = new KvStableStrategy(inputs, {});
+
+  // Find an L1 summary with more than one leaf.
+  let groupLeafIds: ChunkId[] | null = null;
+  for (const [, summary] of inputs.summaries) {
+    if (summary.level !== 1) continue;
+    const node = tree.ancestorAt(summary.chunkIds?.[0] ?? inputs.chunks[0].id, 1);
+    if (node && node.leafChunkIds.length > 1) {
+      groupLeafIds = [...node.leafChunkIds];
+      break;
+    }
+  }
+  assert.ok(groupLeafIds && groupLeafIds.length > 1, 'harness produced a multi-leaf L1 group');
+
+  // Mixed targets inside the group: first leaf wants L1, siblings want raw.
+  const target = new Map<ChunkId, number>();
+  for (const c of inputs.chunks) target.set(c.id, 0);
+  target.set(groupLeafIds![0], 1);
+
+  // White-box injection: selectNextFold only solves when target is unset.
+  (strategy as unknown as { target: Map<ChunkId, number> }).target = target;
+
+  return { strategy, groupLeafIds: groupLeafIds! };
+}
+
+test('cycle guard: mixed-target group terminates instead of oscillating to the iteration bound', () => {
+  const ch = buildChronicleWithChain({
+    chunkCount: 12,
+    tokensPerChunk: 1000,
+    mergeThreshold: 6,
+    recallPairTokens: 200,
+  });
+  const inputs = inputsOf(ch);
+  const { strategy } = strategyWithMixedTargetGroup(inputs);
+
+  // Pre-fix behavior: the raise/lower ping-pong on the same group root ran
+  // to the iteration bound — max(1000, 10×12) = 1000 iterations — and threw
+  // "exceeded iteration bound". With the guard, the walk stops after at
+  // most ~8 emissions per op key and the run RETURNS.
+  const result = new Picker(strategy).run(inputs, BUDGET(100_000));
+
+  assert.ok(
+    result.iterations < 100,
+    `walk terminates quickly under the guard (took ${result.iterations} iterations; ` +
+      `pre-fix this ran to the 1000-iteration bound and threw)`,
+  );
+});
+
+test('cycle guard: per-op emissions are bounded and the result stays renderable', () => {
+  const ch = buildChronicleWithChain({
+    chunkCount: 12,
+    tokensPerChunk: 1000,
+    mergeThreshold: 6,
+    recallPairTokens: 200,
+  });
+  const inputs = inputsOf(ch);
+  const { strategy } = strategyWithMixedTargetGroup(inputs);
+
+  const result = new Picker(strategy).run(inputs, BUDGET(100_000));
+
+  // No single (kind, groupRoot) op may exceed the guard threshold.
+  const emitted = new Map<string, number>();
+  for (const op of result.applied) {
+    const key = `${op.kind}:${String(op.groupRoot)}`;
+    emitted.set(key, (emitted.get(key) ?? 0) + 1);
+  }
+  for (const [key, n] of emitted) {
+    assert.ok(n <= 8, `op ${key} emitted ${n} times — guard threshold is 8`);
+  }
+
+  // Every chunk ends at a definite, in-range resolution (renderable frontier).
+  for (const c of inputs.chunks) {
+    const level = result.finalResolutions.get(c.id);
+    assert.ok(
+      typeof level === 'number' && level >= 0,
+      `chunk ${String(c.id)} has a definite final resolution`,
+    );
+  }
+});
+
+test('no-guard-interference: a consistent frontier still converges exactly (existing behavior)', () => {
+  const ch = buildChronicleWithChain({
+    chunkCount: 48,
+    tokensPerChunk: 1000,
+    mergeThreshold: 6,
+    recallPairTokens: 200,
+  });
+  const inputs = inputsOf(ch);
+  const strategy = new KvStableStrategy(inputs, {});
+  const result = new Picker(strategy).run(inputs, BUDGET(15_000));
+
+  // The guard must be invisible on healthy stores: the picker still reaches
+  // the strategy's own solved target exactly.
+  const target = strategy.targetFrontier();
+  assert.ok(target, 'strategy solved a target');
+  for (const [id, level] of target!) {
+    const chunk = inputs.chunks.find((c) => c.id === id);
+    if (chunk?.pinned || chunk?.lockedByAgent) continue;
+    assert.equal(
+      result.finalResolutions.get(id),
+      level,
+      `chunk ${String(id)} reaches its planned level`,
+    );
+  }
+});

--- a/test/message-store-cache.test.ts
+++ b/test/message-store-cache.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Regression tests for the message-store materialized-cache rework
+ * (2026-07-25).
+ *
+ * `getAllInternal()` caches the deserialized messages array keyed on the
+ * STORE-GLOBAL chronicle sequence. Before this fix, ANY write to any other
+ * state slot (summary appends, autobio counters, framework/state, …)
+ * bumped the sequence and invalidated the cache — so ingest-time chunk
+ * rebuilds (which call getAll() on every new message) paid a full
+ * state-slot re-materialization per message. On a 13.5k-message store with
+ * inline images that was ~10s of blocked event loop per ingested message:
+ * ambient traffic arrived faster than it could be ingested and the agent
+ * looked permanently wedged (the mythos incident).
+ *
+ * The fix: mutators write through the cache (append pushes, edit replaces,
+ * remove splices; range/bodyGroup removals invalidate), and when only
+ * foreign slots moved the sequence the cache revalidates in O(1) via
+ * item-count + last-record identity instead of re-materializing.
+ *
+ * These tests pin CORRECTNESS of every new cache path. (The perf win is
+ * measured, not asserted — timing assertions flake in CI.)
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-message-store-cache';
+
+function cleanup(): void {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+function textBlock(text: string): ContentBlock[] {
+  return [{ type: 'text', text }];
+}
+
+function texts(manager: ContextManager): string[] {
+  const { messages } = manager.queryMessages({});
+  return messages.map((m) => {
+    const b = m.content[0];
+    return b && b.type === 'text' ? b.text : `[${b?.type}]`;
+  });
+}
+
+async function openManager(): Promise<ContextManager> {
+  // Autobiographical strategy so background state appends (counters,
+  // resolutions, …) interleave with message appends — exactly the foreign
+  // sequence bumps the revalidation path exists for.
+  const strategy = new AutobiographicalStrategy({ targetChunkTokens: 300 });
+  return ContextManager.open({ path: TEST_STORE_PATH, strategy });
+}
+
+describe('MessageStore — materialized cache write-through & revalidation', () => {
+  before(cleanup);
+  after(cleanup);
+  beforeEach(cleanup);
+
+  it('append write-through: reads after each append see exactly the appended tail', async () => {
+    const manager = await openManager();
+
+    const expected: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      // Interleave a read between appends so the cache is warm when the
+      // next append writes through it (the hot ingest pattern).
+      manager.addMessage('user', textBlock(`m${i}`));
+      expected.push(`m${i}`);
+      assert.deepEqual(texts(manager), expected, `after append ${i}`);
+    }
+  });
+
+  it('foreign state-slot writes do not corrupt or stale the cache (revalidation path)', async () => {
+    const manager = await openManager();
+    const store = manager.getStore();
+
+    manager.addMessage('user', textBlock('a'));
+    manager.addMessage('user', textBlock('b'));
+    assert.deepEqual(texts(manager), ['a', 'b'], 'warm the cache');
+
+    // Bump the store-global sequence with writes the messages slot never
+    // sees. Pre-fix this invalidated the cache (correct but quadratic);
+    // post-fix the O(1) revalidation must return the SAME content.
+    store.setStateJson('test/foreign-slot', { tick: 1 });
+    store.setStateJson('test/foreign-slot', { tick: 2 });
+    assert.deepEqual(texts(manager), ['a', 'b'], 'unchanged after foreign writes');
+
+    // And a subsequent append still lands correctly on the revalidated cache.
+    manager.addMessage('user', textBlock('c'));
+    assert.deepEqual(texts(manager), ['a', 'b', 'c'], 'append after revalidation');
+  });
+
+  it('edit write-through: edited content is visible without re-materialization', async () => {
+    const manager = await openManager();
+
+    const id = manager.addMessage('user', textBlock('original'));
+    manager.addMessage('user', textBlock('tail'));
+    assert.deepEqual(texts(manager), ['original', 'tail']);
+
+    manager.editMessage(id, textBlock('edited'));
+    assert.deepEqual(texts(manager), ['edited', 'tail'], 'edit visible through cache');
+
+    // Edit is also correct when foreign writes intervene before the read.
+    manager.getStore().setStateJson('test/foreign-slot', { tick: 3 });
+    assert.deepEqual(texts(manager), ['edited', 'tail'], 'edit survives revalidation');
+  });
+
+  it('remove write-through: single removal splices correctly at head, middle, and tail', async () => {
+    const manager = await openManager();
+
+    const ids: string[] = [];
+    for (const t of ['a', 'b', 'c', 'd', 'e']) {
+      ids.push(manager.addMessage('user', textBlock(t)));
+    }
+    assert.deepEqual(texts(manager), ['a', 'b', 'c', 'd', 'e']);
+
+    manager.removeMessage(ids[2]); // middle
+    assert.deepEqual(texts(manager), ['a', 'b', 'd', 'e'], 'middle removal');
+
+    manager.removeMessage(ids[0]); // head
+    assert.deepEqual(texts(manager), ['b', 'd', 'e'], 'head removal');
+
+    manager.removeMessage(ids[4]); // tail
+    assert.deepEqual(texts(manager), ['b', 'd'], 'tail removal');
+
+    // Appends after removals continue from the correct state.
+    manager.addMessage('user', textBlock('f'));
+    assert.deepEqual(texts(manager), ['b', 'd', 'f'], 'append after removals');
+  });
+
+  it('range removal invalidates cleanly', async () => {
+    const manager = await openManager();
+
+    const ids: string[] = [];
+    for (const t of ['a', 'b', 'c', 'd', 'e']) {
+      ids.push(manager.addMessage('user', textBlock(t)));
+    }
+    assert.deepEqual(texts(manager), ['a', 'b', 'c', 'd', 'e'], 'warm the cache');
+
+    manager.removeMessages(ids[1], ids[3]);
+    assert.deepEqual(texts(manager), ['a', 'e'], 'range removed');
+
+    manager.addMessage('user', textBlock('f'));
+    assert.deepEqual(texts(manager), ['a', 'e', 'f'], 'append after range removal');
+  });
+
+  it('branch operations see the correct per-branch message set', async () => {
+    const manager = await openManager();
+
+    manager.addMessage('user', textBlock('a'));
+    const forkId = manager.addMessage('user', textBlock('b'));
+    manager.addMessage('user', textBlock('c'));
+    assert.deepEqual(texts(manager), ['a', 'b', 'c'], 'warm the cache on the main branch');
+
+    manager.branchAt(forkId, 'fork-test');
+    // branchAt creates the branch without switching — the warm cache must
+    // still serve the current branch unchanged.
+    assert.deepEqual(texts(manager), ['a', 'b', 'c'], 'current branch unchanged after branchAt');
+
+    await manager.switchBranch('fork-test');
+    // The fork contains messages up to and including the fork point; the
+    // cache is keyed by branch name and must not leak the old branch's tail.
+    assert.deepEqual(texts(manager), ['a', 'b'], 'fork sees the truncated set');
+
+    manager.addMessage('user', textBlock('d'));
+    assert.deepEqual(texts(manager), ['a', 'b', 'd'], 'append on the fork');
+  });
+});


### PR DESCRIPTION
## Context

Mythos went hard-down on 2026-07-25 (~06:53Z): 100% CPU, event loop starved (no replies, no webui, no signal handlers), and every restart re-wedged within a minute. Diagnosis (breadcrumb bisect → faithful offline repro under \`node --prof\`) found **two independent context-manager bugs**, both triggered by the same store condition: chunk-ownership drift after store surgery / branch rollback (the \`head boundary disagrees with chunk ownership\` warning).

## Fix 1 — kv-stable: cycle guard in the fold walk (the actual wedge)

\`nextOp\` emits raise/lower ops against a whole **group root**, but the solved target frontier is **per-chunk**. A group whose leaves carry mixed targets makes the walk ping-pong on the same root: raising the group for one leaf overshoots its siblings, lowering for a sibling undoes the raise. The picker's iteration bound is \`max(1000, 10×chunks)\` at O(chunks) per step — on a live 13.5k-message store that's **hours of blocked event loop per compile**, re-fired on every wake (heartbeat included, hence boots wedging).

The guard counts emissions per \`(kind, groupRoot)\`; >8 means cycling, not walking: warn once (\`[kv-stable] non-converging fold walk\`), treat the chunk as unrealizable, render the nearest realizable frontier. A consistent frontier still converges exactly (asserted).

Solve-side group-consistency (why mixed targets can exist at all under ownership drift) is left as follow-up — the guard makes the failure mode a logged degradation instead of an outage.

## Fix 2 — message-store: write-through materialized cache (quadratic ingest)

\`getAllInternal()\`'s cache was keyed on the **store-global** sequence, so any other slot's write (summary appends, counters, framework/state) invalidated it — and \`rebuildChunks\` calls \`getAll()\` on **every ingested message**. Full state-slot serde + blob decode per message ≈ **9.5s at 13.5k messages** with inline images: ambient traffic outran ingest and the agent looked permanently wedged.

Now append/edit write through the cache using the **chronicle round-trip form** (via \`getStateItemJson\`) — serde reorders keys / drops undefined, and request hashing stringifies content, so a hand-built object breaks hash-keyed dedup (caught by the compression-recall-curve suite during development). Single remove splices; range/bodyGroup removals invalidate; foreign-slot sequence bumps revalidate in O(1) (count + last-record identity). Chronicles without \`getStateItemJson\` keep the old behavior (the fallback would recurse).

**Measured: 9.5s → 250ms per ingested message** on a copy of the mythos store.

## Testing

- New: \`test/adaptive/kv-cycle-guard.test.ts\` (fails on main — runs to the iteration bound; passes with the guard), \`test/message-store-cache.test.ts\` (all new cache paths incl. foreign-slot revalidation and branch switching).
- Full suite: **412 tests, 388 pass, 20 fail — failure set byte-identical to main's pre-existing failures** (verified by stash-diffing the failing-test lists).
- Live-verified on mythos: hung-forever compile → 5-15s; agent recovered, turns clean.

## Deploy notes

- mythos (ubuntu@mythos.animalabs.ai) currently runs a hand-patched near-identical version of both fixes (backups \`*.bak-cycleguard-20260725\`, \`*.bak-ingestcache-20260725\`); it should be moved onto this branch/main once merged — its append write-through predates the round-trip-canonical fix.
- The \`[kv-stable]\` warning will keep firing on mythos until the underlying L4-936 ownership drift is repaired (separate task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)