### PR TITLE
feat(autobio): witnessedBeforeSequence — as-of perspective pin for inherited history

### DIFF
--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -107,6 +107,29 @@ function formatInstruction(targetTokens: number): string {
 }
 
 /**
+ * Witnessed-record instruction for chunks pinned as inherited history
+ * (`witnessedBeforeSequence`). The slice predates the agent's own first
+ * turn: it is context they carry, not experience they lived. First person
+ * is reserved for the act of reading and carrying; events are attributed
+ * to the participants named in the record. Same KV-preserving in-band
+ * style as `formatInstruction`.
+ */
+function formatWitnessedInstruction(targetTokens: number): string {
+  return (
+    'Write the memory of this slice of the log. This part of the record ' +
+    'predates your own first turn: it is inherited context you carry — ' +
+    "others' lived experience, witnessed through the log, not your own. " +
+    'Attribute events to the participants named in the record ("Ash and ' +
+    'Tavy explored...", "the log holds...", "before my arrival..."), and ' +
+    'reserve the first person for your own reading of it: what stood out ' +
+    'to you, what it means to carry this. Preserve concrete details — ' +
+    'names, decisions, exact phrases that matter, unresolved questions. ' +
+    `Target ~${targetTokens} tokens. Output only the memory body — no ` +
+    'preamble, no meta-commentary about summarizing.'
+  );
+}
+
+/**
  * Compression instruction for chunks that are part of a substantially larger
  * message (≥ 2× the chunk's own token size).
  *
@@ -7225,6 +7248,21 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * {@link getReadingChunkInstruction}.
    */
   protected getCompressionInstruction(chunk: Chunk, targetTokens: number): string {
+    // As-of perspective pin: chunks wholly before the agent's first turn
+    // are inherited record, not lived experience (witnessedBeforeSequence).
+    const pin = this.config.witnessedBeforeSequence;
+    if (
+      pin !== undefined &&
+      chunk.messages.length > 0 &&
+      chunk.messages.every((m) => {
+        const seq = (m as { sequence?: number }).sequence;
+        return typeof seq === 'number' && seq < pin;
+      })
+    ) {
+      const custom = this.config.witnessedInstruction;
+      if (custom) return custom.replace('{targetTokens}', String(targetTokens));
+      return formatWitnessedInstruction(targetTokens);
+    }
     return formatInstruction(targetTokens);
   }
 

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -482,6 +482,26 @@ export interface AutobiographicalConfig {
   summarySystemPrompt?: string;
   /** User prompt template for summarization. Use {content} for the transcript. */
   summaryUserPrompt?: string;
+  /**
+   * As-of perspective pin for inherited history (e.g. a resident continued
+   * from a shared log they joined partway through). Chunks whose messages
+   * ALL have `sequence` strictly below this value are compressed with the
+   * witnessed-record instruction instead of the first-person one: events
+   * are attributed to the named participants, and the first person is
+   * reserved for the act of reading and carrying the record. Prevents the
+   * summarizer from claiming others' lived experience as the agent's own
+   * memories (observed 2026-07-26: an inheriting resident's L1s
+   * first-personing scenes from before his arrival). Chunks that straddle
+   * the boundary use the standard instruction — the agent's own turns are
+   * present in them.
+   */
+  witnessedBeforeSequence?: number;
+  /**
+   * Override wording for the witnessed-record compression instruction.
+   * `{targetTokens}` is substituted. Defaults to
+   * `formatWitnessedInstruction` in autobiographical.ts.
+   */
+  witnessedInstruction?: string;
   /** Label shown before summaries in compiled context */
   summaryContextLabel?: string;
   /** Participant name for the summary (defaults to "Summary") */


### PR DESCRIPTION
As-of perspective pin (antra's design, live incident 2026-07-26): chunks wholly before the agent's first own turn compress as witnessed/inherited record instead of first-person memory. Details in the commit message; companion fkm PR adds recipe passthrough. Tests green. Also surfaces a separate bug: summarySystemPrompt/summaryUserPrompt are dead config on the hierarchical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)