### PR TITLE
fix(autobio): cache markers fit the global 4-breakpoint budget (reserve system slot)

### DIFF
--- a/src/message-store.ts
+++ b/src/message-store.ts
@@ -36,11 +36,24 @@ function bumpWriteVersion(store: object, stateId: string): number {
   }
   const next = (m.get(stateId) ?? 0) + 1;
   m.set(stateId, next);
+  if (typeof process !== 'undefined' && process.env?.CM_CACHE_DIAG) {
+    const site = (new Error().stack ?? '').split('\n')[2]?.trim();
+    console.error(`[cm-cache] writeVersion bump ${stateId} → ${next} at ${site}`);
+  }
   return next;
 }
 
 function currentWriteVersion(store: object, stateId: string): number {
   return sharedWriteVersions.get(store)?.get(stateId) ?? 0;
+}
+
+/** CM_CACHE_DIAG=1: log every materialization-cache miss with its REASON and
+ *  cost, every invalidating mutation, and every write-through fallback. The
+ *  full rebuild is ~20s of CPU on a large store on production hardware —
+ *  a silent cache miss IS the latency incident (mythos, 2026-07-26). */
+const CACHE_DIAG = typeof process !== 'undefined' && !!process.env?.CM_CACHE_DIAG;
+function cacheDiag(msg: string): void {
+  if (CACHE_DIAG) console.error(`[cm-cache] ${msg}`);
 }
 
 /**
@@ -311,6 +324,11 @@ export class MessageStore {
       // quadratic ingest this write-through exists to prevent.
       this.allCache.writeVersion = currentWriteVersion(this.store, this.stateId);
     } else {
+      if (this.allCache) {
+        cacheDiag(
+          `append write-through FAILED (${!canPointLookup ? 'no point lookup' : !canonical ? 'canonical null' : this.allCache.branch !== this.store.currentBranch().name ? 'branch mismatch' : `length mismatch cache=${this.allCache.internals.length} index=${index}`}) — cache dropped`,
+        );
+      }
       this.allCache = null;
     }
 
@@ -854,6 +872,15 @@ export class MessageStore {
     const branch = this.store.currentBranch().name;
     const sequence = this.store.currentSequence();
     const writeVersion = currentWriteVersion(this.store, this.stateId);
+    let missReason = 'no-cache';
+    if (this.allCache) {
+      missReason =
+        this.allCache.branch !== branch
+          ? `branch ${this.allCache.branch}→${branch}`
+          : this.allCache.writeVersion !== writeVersion
+            ? `writeVersion ${this.allCache.writeVersion}→${writeVersion}`
+            : 'revalidate-fail';
+    }
     if (this.allCache && this.allCache.branch === branch && this.allCache.writeVersion === writeVersion) {
       if (this.allCache.sequence === sequence) {
         return this.allCache.internals;
@@ -889,12 +916,17 @@ export class MessageStore {
           this.allCache.sequence = sequence;
           return this.allCache.internals;
         }
+        missReason = `revalidate-fail last-item (cached ${lastCached?.id}/${lastCached?.sequence} live ${lastLive?.id}/${lastLive?.sequence})`;
+      } else {
+        missReason = `revalidate-fail count (cached ${this.allCache.internals.length} live ${count}${canPointLookup ? '' : ', no point lookup'})`;
       }
     }
+    const _t = CACHE_DIAG ? Date.now() : 0;
     const state = this.store.getStateJson(this.stateId);
     const internals =
       !state || !Array.isArray(state) ? [] : (state as StoredMessageInternal[]);
     this.allCache = { branch, sequence, internals, writeVersion };
+    cacheDiag(`getAllInternal MISS (${missReason}) stateId=${this.stateId} rebuilt ${internals.length} in ${Date.now() - _t}ms`);
     return internals;
   }
 

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -6411,6 +6411,22 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     if (historyEnd - lastHead > 2) marks.add(lastHead + Math.floor((historyEnd - lastHead) / 2)); // mid-history
     marks.add(n - 1);                                            // end → pure-append reuse
 
+    // The Anthropic limit is 4 cache_control blocks per request INCLUDING the
+    // system block, which membrane marks whenever prompt caching is on. So
+    // message-level markers must never exceed 3 — with all four seams placed
+    // (possible only once folds exist; pre-fold only 2 seams materialize) the
+    // request hard-400s: "A maximum of 4 blocks with cache_control may be
+    // provided. Found 5." (Rhys, 2026-07-26 — his first fold-active compile.)
+    // Drop the mid-history seam first: head and folded-prefix markers protect
+    // the expensive stable prefixes and the end marker buys pure-append
+    // reuse; the mid seam is the cheapest to lose. Deliberately NOT fixed by
+    // stripping in membrane — silently dropped markers are silently broken
+    // caching, which is an invisible-cost bug; the supplier stays within the
+    // global budget instead.
+    if (marks.size > 3) {
+      marks.delete(lastHead + Math.floor((historyEnd - lastHead) / 2));
+    }
+
     for (const idx of marks) if (idx >= 0 && idx < n) entries[idx].cacheMarker = true;
   }
 


### PR DESCRIPTION
First fold-active compile places all four message seams; membrane marks system too → 5 cache_control blocks → hard 400 (Rhys tonight). Cap at 3, drop mid-history seam. Supplier-side by design: membrane must never silently strip markers (silent cache breakage = invisible cost). Tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)