### PR TITLE
docs: contribution guidelines, PR template, changelog policy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Problem
+
+<!-- What is wrong / missing, and for whom. Link the issue if one exists. -->
+
+## Changes
+
+<!-- What this PR does. For cross-repo or stacked work, list companion PRs
+     and merge-order guidance ("safe in either order because…"). -->
+
+## Tests
+
+<!-- Evidence, not assertion: paste the numbers.
+     e.g. `npm test`: 187 pass / 0 fail — failure count identical to main baseline.
+     Tests run from dist/, so `npm run build` first. -->
+
+## Not verified
+
+<!-- Compression behavior is emergent: a strategy change can pass the suite
+     and still degrade on a real store. Say whether you compiled against one,
+     at what size, and what you did not exercise. "Nothing — verified against
+     a 200k-token store" is a fine answer; silence is not. -->
+
+---
+
+- [ ] `CHANGELOG.md` updated under `## Unreleased` — or this change is
+      internal-only / test-only / docs-only (apply the `no-changelog` label).
+
+<!-- AI-assisted contributions are welcome and normal here — see
+     CONTRIBUTING.md for the attribution convention (footer + Co-Authored-By). -->

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,32 @@
+name: Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog-entry:
+    name: Changelog entry present
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-changelog')"
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Require CHANGELOG.md update when src/ changes
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          changed=$(git diff --name-only "$base...$head")
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -q '^src/' && ! echo "$changed" | grep -qx 'CHANGELOG.md'; then
+            echo "::error::This PR touches src/ but not CHANGELOG.md. Add an entry under 'Unreleased' (see CONTRIBUTING.md), or apply the 'no-changelog' label if the change is internal-only."
+            exit 1
+          fi
+          echo "OK"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,6 +51,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Require changelog section for this release
+        run: |
+          ver="${GITHUB_REF_NAME#v}"
+          esc=$(printf '%s' "$ver" | sed 's/[.]/\\./g')
+          if ! grep -Eq "^## ${esc}([^0-9]|$)" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## ${ver}' section for tag ${GITHUB_REF_NAME}. Retitle the Unreleased section before tagging (see CONTRIBUTING.md)."
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -66,3 +75,40 @@ jobs:
 
       - name: Publish
         run: npm publish --access public --provenance
+
+  github-release:
+    name: GitHub release notes
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    # Deliberately independent of the npm publish job: some consumers run
+    # github-clone checkouts, and release notes must exist even when npm
+    # publish fails — the two jobs succeed or fail on their own.
+    if: startsWith(github.ref, 'refs/tags/v')
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Mirror changelog section into release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ver="${GITHUB_REF_NAME#v}"
+          # Section header is '## X.Y.Z — YYYY-MM-DD'; match the version
+          # field exactly (string compare, no regex escaping needed).
+          awk -v ver="$ver" '
+            /^## / { if (in_section) exit; if ($2 == ver) { in_section = 1; next } }
+            in_section { print }
+          ' CHANGELOG.md | sed '/./,$!d' > notes.md
+          if ! [ -s notes.md ]; then
+            echo "::error::No CHANGELOG.md section found for ${ver}."
+            exit 1
+          fi
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release edit "$GITHUB_REF_NAME" --notes-file notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" \
+              --notes-file notes.md --verify-tag
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Notable changes to `@animalabs/context-manager`, loosely following
+[Keep a Changelog](https://keepachangelog.com/). Entries land with the change
+that causes them — see [CONTRIBUTING.md](CONTRIBUTING.md#changelog).
+
+Releases up to and including 0.6.2 predate this file; for their contents see
+`git log` and the
+[releases page](https://github.com/anima-research/context-manager/releases).
+
+## Unreleased

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,148 @@
+# Contributing to context-manager
+
+context-manager is part of the Connectome ecosystem
+([agent-framework](https://github.com/anima-research/agent-framework),
+[membrane](https://github.com/antra-tess/membrane),
+[chronicle](https://github.com/anima-research/chronicle),
+[connectome-host](https://github.com/anima-research/connectome-host)). These
+conventions describe how work actually lands here — they codify existing
+practice rather than aspiration. When in doubt, recent merged PRs are the best
+reference.
+
+Everything below applies to every change however it lands — external PR or
+maintainer direct push — and to human and AI authors identically. There is
+no separate rulebook for either.
+
+## How changes land
+
+- External contributions come as PRs against `main`, from a fork or a repo
+  branch. Maintainers also land small changes directly on `main`; don't be
+  surprised by history that never saw a PR.
+- Branch names: `feat/<kebab-case>`, `fix/<kebab-case>`, `docs/`, `chore/`.
+  Including the issue number is welcome (`fix/23-budget-descent`).
+- PRs are merged as **true merge commits** — no squash, no rebase-merge.
+  Because nothing is squashed, keep individual commits coherent.
+- To update a stale branch, rebase onto `main` or merge `main` in; both are
+  accepted.
+- Stacked PRs and cross-repo companion PRs are fine, but **declare them** in
+  the body with merge-order guidance ("stacked on #7 — review that first";
+  "safe to merge in either order because …"). This package sits on chronicle
+  and membrane and is consumed by agent-framework and connectome-host, so
+  companion PRs are common; say which side is safe to land first and what
+  happens if only one does.
+
+## What a PR should contain
+
+Body shape (the PR template mirrors this): **Problem / Changes / Tests**,
+plus, when applicable, **Not verified**, **Out of scope**, and
+**Companion PRs**. The conventions that matter:
+
+- **Evidence over assertion.** State the test baseline numerically:
+  "`npm test`: N pass / M fail, failure count identical to `main` baseline."
+  A claim like "all tests pass" without the count will be re-verified anyway,
+  so save the reviewer the trip.
+- **Say what you did NOT verify.** Compression behavior is emergent and
+  hard to unit-test honestly: a strategy change that passes the suite can
+  still degrade on a real store. Say whether you ran it against a real
+  store, at what size, and what you did not exercise. A silent gap that
+  review uncovers is not respected; an honest one is.
+- **Tests accompany behavior changes.** Review scrutinizes test substance,
+  not mere presence — a test that can't fail on the unfixed code will be
+  called out, and a compression test whose fixture is too small to trigger
+  the path it claims to cover is the local specialty of that failure.
+- **Changelog entry** under `## Unreleased` for anything behavior-affecting
+  (see below).
+
+Conventional-commit-style titles (`feat(strategy): …`, `fix(compression): …`)
+are the house default; plain descriptive titles are accepted.
+
+## Review process — what to expect
+
+- Review arrives as **ordinary PR comments**, not GitHub review approvals —
+  the comment thread is the gate. Reviews are frequently AI-generated and
+  explicitly labeled as such, with a severity verdict and itemized findings.
+- The reviewer will typically **run your branch** (typecheck, test suite,
+  often a compile against a real store to see the token curve) and paste
+  transcripts. Claims are checked, not trusted.
+- Respond by pushing fix commits and replying per finding — "Addressed in
+  `<sha>`" — rather than force-pushing a rewritten branch. A re-review then
+  flips the verdict.
+- Maintainers may push small review fixes **directly to your branch** to keep
+  things moving. Say so in the PR body if you'd rather they didn't.
+- PRs are never closed silently: a closed PR gets a one-line disposition
+  comment (usually supersession by another PR).
+
+## AI-assisted contributions
+
+AI-written code is the norm in this ecosystem, welcome from everyone, and
+held to exactly the same evidence standards as anything else. Declare it the
+way we do:
+
+- the `🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+  footer (or equivalent for your tooling) in the PR body, and
+- a `Co-Authored-By:` trailer naming the model in commits.
+
+What earns an automated contribution a changes-requested review is not being
+AI-generated — it's arriving without the suite having been run, with tests
+that don't fail on unfixed code, or with claims the branch itself disproves.
+
+## Changelog
+
+`CHANGELOG.md` keeps a standing `## Unreleased` section with
+`### Breaking` / `### Added` / `### Changed` / `### Fixed` subsections
+(loosely [Keep a Changelog](https://keepachangelog.com/)).
+
+- **The entry lands with the change** — same commit, or at least the same
+  PR. This binds direct pushes to `main` just as much as PRs. On PRs, CI
+  enforces it softly: touching `src/` without touching `CHANGELOG.md` fails
+  the `changelog` check unless the `no-changelog` label is applied.
+- **What needs an entry:** anything a host or strategy author would notice —
+  strategy behavior and option types, compression triggers and thresholds,
+  token budgeting and holdback, pinning, cache-breakpoint placement, what a
+  compile emits, public exports, defaults. Internal refactors, test-only,
+  and docs-only changes don't.
+- **Breaking entries are audience-scoped.** Name the audience in the heading
+  (`### Breaking (host operators only)`) and cover: **who needs to act**,
+  **migration**, and **unchanged** (what readers might fear broke but
+  didn't). Config that becomes *required* is the sharpest case here — an
+  option that starts throwing when unset breaks every recipe that omitted
+  it, and that is exactly what the "who needs to act" line is for.
+- **Keep one `## Unreleased` heading.** Add entries under the existing one;
+  don't open a second. Only the first is cut at release time, so entries
+  filed under a later heading are silently never released — the release
+  script refuses to run if it finds more than one.
+- **Releases** (maintainers): `npm version <patch|minor|major>` does the
+  whole cut — the `version` hook retitles `Unreleased` to
+  `## X.Y.Z — YYYY-MM-DD` (keeping a fresh `Unreleased` above it, and
+  refusing to release when there are no entries), then npm commits and tags.
+  `git push --follow-tags` triggers CI, which refuses a tag with no matching
+  changelog section, publishes `@animalabs/context-manager` to npm, and
+  creates the GitHub release with that section as its notes. The two release
+  jobs are independent: some consumers run github-clone checkouts, so
+  release notes must exist even when npm publish fails. Version bumps are a
+  maintainer release-time action, not part of feature PRs.
+
+## Building and testing
+
+```bash
+npm ci                # strict lockfile install (see below)
+npm run build         # tsc; tests run from dist/, so build first
+npm test              # node --test dist/test/*.test.js dist/test/adaptive/*.test.js
+npx tsc --noEmit      # typecheck
+```
+
+`npm test` runs the compiled output, so a stale `dist/` will happily test
+code you no longer have — always build before testing, and after switching
+branches.
+
+Push-time CI (`ci.yml`) builds, typechecks and tests every push and PR on
+ubuntu and macos, installing with `npm ci`. The lockfile is committed and
+strict: `npm install` on npm >= 11 will quietly re-resolve platform packages
+missing from the lock, so only `npm ci` fails loudly on a lock that is broken
+or out of sync. If you change dependencies, commit the regenerated lock — and
+note that a lock regenerated over an existing `node_modules` tree records
+only your platform's native binaries, which is why CI installs on both.
+
+`bench/` and `playground/` hold the harnesses for looking at real compression
+behavior rather than fixtures; `docs/` carries the design notes behind the
+strategies.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc --noEmit",
     "pretest": "npm run build",
     "test": "node --test dist/test/*.test.js dist/test/adaptive/*.test.js",
+    "version": "node scripts/release-changelog.mjs && git add CHANGELOG.md",
     "prepublishOnly": "npm run build"
   },
   "keywords": [

--- a/scripts/release-changelog.mjs
+++ b/scripts/release-changelog.mjs
@@ -1,0 +1,58 @@
+// Runs as npm's `version` lifecycle hook (see package.json): at that point
+// package.json already carries the new version, and files staged here are
+// included in the release commit that `npm version` then creates and tags.
+//
+// Cuts the standing `## Unreleased` section into `## X.Y.Z — YYYY-MM-DD` and
+// leaves a fresh empty `## Unreleased` above it. Refuses to release when
+// there is nothing to release, or when the file's shape is ambiguous.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const path = "CHANGELOG.md";
+const { version } = JSON.parse(readFileSync("package.json", "utf8"));
+const text = readFileSync(path, "utf8");
+
+const fail = (msg) => {
+  console.error(`CHANGELOG.md: ${msg}`);
+  process.exit(1);
+};
+
+// Exactly one Unreleased heading. A second one silently strands entries:
+// only the first is ever cut, so anything filed under a later heading is
+// never released and never reaches the GitHub release notes.
+const headings = [...text.matchAll(/^## Unreleased[ \t]*$/gm)];
+if (headings.length === 0) {
+  fail("no '## Unreleased' section — add one before releasing.");
+}
+if (headings.length > 1) {
+  const lines = headings.map((m) => text.slice(0, m.index).split("\n").length);
+  fail(
+    `${headings.length} '## Unreleased' headings (lines ${lines.join(", ")}). ` +
+      "Only the first is released; fold them into one before releasing.",
+  );
+}
+const [header] = headings;
+
+const escaped = version.replace(/[.]/g, "\\.");
+if (new RegExp(`^## ${escaped}([^0-9]|$)`, "m").test(text)) {
+  fail(`a '## ${version}' section already exists.`);
+}
+
+const afterHeader = text.slice(header.index + header[0].length);
+const nextSection = afterHeader.search(/^## /m);
+const body = nextSection === -1 ? afterHeader : afterHeader.slice(0, nextSection);
+if (!/^[ \t]*[-*] /m.test(body)) {
+  fail(`'## Unreleased' has no entries — nothing to release as ${version}.`);
+}
+
+// Spliced by index rather than string-replaced: `text.replace("## Unreleased", …)`
+// would hit the first *substring* occurrence, which is not necessarily the
+// heading the regex matched (an inline mention of `## Unreleased` in prose
+// comes first) and would inject the version heading into the wrong place.
+const date = new Date().toISOString().slice(0, 10);
+writeFileSync(
+  path,
+  text.slice(0, header.index) +
+    `## Unreleased\n\n## ${version} — ${date}` +
+    text.slice(header.index + header[0].length),
+);
+console.log(`CHANGELOG.md: cut Unreleased into '## ${version} — ${date}'.`);


### PR DESCRIPTION
Ports the ecosystem contribution/changelog policy (conhost PR #49, the 172-PR norms survey) to context-manager: CONTRIBUTING.md, PR template, CHANGELOG.md seed, a PR-time changelog guard, the release-time tag guard, and the GitHub-release-notes job in publish.yml. `npm version` retitles the Unreleased section via `scripts/release-changelog.mjs`.

This was written Jul 13 and sat unpushed; landing it now because a follow-up PR (chunk-boundary hook + saturation gates, incident-driven) wants the changelog process to exist before it binds itself to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)