### PR TITLE
feat(chunker): chunkBoundaryHint subclass seam + budget-saturation liveness gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,29 @@ Releases up to and including 0.6.2 predate this file; for their contents see
 [releases page](https://github.com/anima-research/context-manager/releases).
 
 ## Unreleased
+
+### Added
+
+- **`chunkBoundaryHint` — a subclass seam for semantic chunk boundaries.**
+  Strategies with domain knowledge about conversation structure (chat-topic
+  transitions, episode breaks) can close a chunk early at a semantic boundary
+  without forking `rebuildChunks` — hinted closes persist chunk records and
+  respect the minimum-size and tool_use-pairing guards exactly like size-based
+  closes. Motivation: connectome-host's FrontdeskStrategy forked the whole
+  chunker for topic-aware boundaries and silently bypassed chunk-record
+  persistence and the fail-closed orphan guard.
+- **Budget-saturation liveness gates** (`test/long-context-saturation.test.ts`)
+  — the regression net for the 2026-08-03 production outage class (hierarchical
+  renderer saturating its fixed budget into a terminal `UncoveredDropError`
+  refusal loop): the adaptive path must compile every turn of a workload whose
+  raw history is several times the budget, and under pathological pressure may
+  refuse only with the recoverable `OverBudgetError` class, never an uncovered
+  drop.
+
+### Changed
+
+- The adaptive path's tail-shortfall and newest-turn-retention refusals now
+  name their stage (`Tail emission dropped reserved recent-window messages`,
+  `Structural repair did not retain the newest turn`) instead of masquerading
+  as picker exhaustion with impossible arithmetic ("742 tokens still exceed
+  hard budget 11220").

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -6683,6 +6683,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const tailStats = this.emitRecentNewestFirst(entries, store, messages, effectiveRecentStart, msgCap, rejectionBudget, totalTokens, pse);
     if (tailStats.messages !== messages.length - effectiveRecentStart) {
       throw new OverBudgetError({
+        stage: 'Tail emission dropped reserved recent-window messages',
         budget: rejectionBudget,
         actual: totalTokens + tailTokens,
         diagnostics: {
@@ -6736,6 +6737,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       );
       if (!newestRetained) {
         throw new OverBudgetError({
+          stage: 'Structural repair did not retain the newest turn',
           budget: rejectionBudget,
           actual: totalTokens + tailTokens,
           diagnostics: {
@@ -8169,12 +8171,57 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     let currentTokens = 0;
     let chunkFilteredStart = 0;
 
+    // Close the running chunk over [chunkFilteredStart, endExclusive). Shared
+    // by the size-based close and the subclass boundary hint below — both
+    // persist the boundary identically.
+    const closeCurrent = (endExclusive: number): void => {
+      const chunk: Chunk = {
+        index: this.chunks.length,
+        startIndex: chunkFilteredStart,
+        endIndex: endExclusive,
+        messages: [...currentChunk],
+        tokens: currentTokens,
+        compressed: false,
+      };
+      // Persist the boundary the moment it closes — from here on this
+      // span is owned and never re-keyed by config drift or restarts.
+      if (this.chunkPersistenceEnabled) {
+        const record: ChunkRecord = {
+          id: `c-${this.chunkIdCounter++}`,
+          sourceIds: chunk.messages.map(m => m.id),
+          compressed: false,
+        };
+        this.appendChunkRecord(record);
+        chunk.recordId = record.id;
+      }
+      this.chunks.push(chunk);
+      this.compressionQueue.push(chunk.index);
+
+      currentChunk = [];
+      currentTokens = 0;
+      chunkFilteredStart = endExclusive;
+    };
+
     for (let i = 0; i < messagesToChunk.length; i++) {
       const msg = messagesToChunk[i];
       let msgTokens = store.estimateTokens(msg);
 
       if (this.config.attachmentsIgnoreSize) {
         msgTokens = this.estimateTextOnlyTokens(msg);
+      }
+
+      // Subclass boundary hint: close BEFORE appending `msg` when the
+      // subclass marks a semantic boundary between the running chunk's last
+      // message and this one (e.g. a chat-topic transition). An undersized
+      // boundary chunk is deliberate — a semantic boundary outranks the size
+      // target — but the chunker's minimum message count and the tool_use
+      // pairing guard below still apply.
+      if (
+        currentChunk.length >= 4 &&
+        !this.lastMessageContainsToolUse(currentChunk) &&
+        this.chunkBoundaryHint(currentChunk[currentChunk.length - 1], msg, currentChunk)
+      ) {
+        closeCurrent(i);
       }
 
       currentChunk.push(msg);
@@ -8196,31 +8243,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       }
 
       if (shouldClose) {
-        const chunk: Chunk = {
-          index: this.chunks.length,
-          startIndex: chunkFilteredStart,
-          endIndex: i + 1,
-          messages: [...currentChunk],
-          tokens: currentTokens,
-          compressed: false,
-        };
-        // Persist the boundary the moment it closes — from here on this
-        // span is owned and never re-keyed by config drift or restarts.
-        if (this.chunkPersistenceEnabled) {
-          const record: ChunkRecord = {
-            id: `c-${this.chunkIdCounter++}`,
-            sourceIds: chunk.messages.map(m => m.id),
-            compressed: false,
-          };
-          this.appendChunkRecord(record);
-          chunk.recordId = record.id;
-        }
-        this.chunks.push(chunk);
-        this.compressionQueue.push(chunk.index);
-
-        currentChunk = [];
-        currentTokens = 0;
-        chunkFilteredStart = i + 1;
+        closeCurrent(i + 1);
       }
     }
 
@@ -8246,6 +8269,27 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         return lastId !== undefined && this._demandedL1Chunks.has(lastId);
       });
     }
+  }
+
+  /**
+   * Subclass seam consulted between two adjacent frontier messages during
+   * chunking: return true to close the running chunk BEFORE `next` is
+   * appended — e.g. at a conversation-topic transition — even though the
+   * running sum has not reached `targetChunkTokens`. Keeping unrelated
+   * topics out of one chunk keeps their summaries from being fused.
+   *
+   * Consulted only once the running chunk has the chunker's minimum message
+   * count, and never overrides the tool_use pairing guard. The base never
+   * hints, so boundaries are unchanged for strategies that don't override
+   * this. Hinted closes persist chunk records exactly like size-based ones.
+   */
+  protected chunkBoundaryHint(
+    prev: StoredMessage,
+    next: StoredMessage,
+    currentChunk: readonly StoredMessage[],
+  ): boolean {
+    void prev; void next; void currentChunk;
+    return false;
   }
 
   /**

--- a/test/chunk-boundary-hook.test.ts
+++ b/test/chunk-boundary-hook.test.ts
@@ -1,0 +1,196 @@
+/**
+ * `chunkBoundaryHint` — the subclass seam for semantic chunk boundaries.
+ *
+ * Host strategies with domain knowledge about conversation structure
+ * (e.g. chat-topic transitions in connectome-host's FrontdeskStrategy)
+ * previously had to fork the whole of `rebuildChunks` to close chunks at
+ * semantic boundaries — bypassing chunk-record persistence, the
+ * fail-closed orphan guard, and every future fix to the base chunker.
+ * The hint hook lets them keep semantic boundaries while riding the base
+ * implementation.
+ *
+ * Contract under test:
+ *  1. A hint between two frontier messages closes the running chunk
+ *     BEFORE the next message is appended, even under `targetChunkTokens`.
+ *  2. The hint is not consulted until the chunk has the chunker's minimum
+ *     message count (4).
+ *  3. The tool_use pairing guard outranks the hint: a chunk never closes
+ *     on a trailing tool_use, topic boundary or not.
+ *  4. Hinted closes persist chunk records exactly like size-based closes.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { StoredMessage } from '../src/types/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-chunk-boundary-hook';
+
+function cleanup() {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+/** Closes chunks whenever `metadata.topic` changes between neighbors. */
+class TopicBoundaryStrategy extends AutobiographicalStrategy {
+  protected override chunkBoundaryHint(prev: StoredMessage, next: StoredMessage): boolean {
+    const topicOf = (m: StoredMessage): unknown =>
+      (m.metadata as Record<string, unknown> | undefined)?.topic;
+    const a = topicOf(prev);
+    const b = topicOf(next);
+    return a !== undefined && b !== undefined && a !== b;
+  }
+}
+
+interface StrategyInternals {
+  chunks: Array<{
+    recordId?: string;
+    messages: Array<{ id: string; content: ContentBlock[]; metadata?: Record<string, unknown> }>;
+  }>;
+  chunkRecords: Array<{ id: string; sourceIds: string[]; compressed: boolean }>;
+  rebuildChunks: (store: unknown) => void;
+}
+
+function internals(strategy: AutobiographicalStrategy): StrategyInternals {
+  return strategy as unknown as StrategyInternals;
+}
+
+async function openManager(strategy: AutobiographicalStrategy): Promise<ContextManager> {
+  return ContextManager.open({ path: TEST_STORE_PATH, strategy });
+}
+
+function rebuild(manager: ContextManager, strategy: AutobiographicalStrategy): void {
+  internals(strategy).rebuildChunks(
+    (manager as unknown as { messageStore: unknown }).messageStore,
+  );
+}
+
+const filler = (n: number) => 'word '.repeat(n);
+
+describe('Chunker: subclass boundary hint', () => {
+  before(() => cleanup());
+  after(() => cleanup());
+
+  it('closes an undersized chunk at a hinted boundary, and persists its record', async () => {
+    cleanup();
+    const strategy = new TopicBoundaryStrategy({
+      // Size-close would need 10k tokens — far beyond this workload, so any
+      // close we observe is the hint's.
+      targetChunkTokens: 10_000,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+    });
+    const manager = await openManager(strategy);
+
+    // 5 messages on topic alpha (past the 4-message minimum), then 5 on
+    // topic beta. The alpha→beta transition must close the alpha chunk.
+    for (let i = 0; i < 5; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent',
+        [{ type: 'text', text: filler(20) }], { topic: 'alpha' });
+    }
+    for (let i = 0; i < 5; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent',
+        [{ type: 'text', text: filler(20) }], { topic: 'beta' });
+    }
+
+    rebuild(manager, strategy);
+    const s = internals(strategy);
+
+    assert.strictEqual(s.chunks.length, 1, 'exactly the alpha chunk should have closed');
+    const topics = new Set(s.chunks[0].messages.map((m) => m.metadata?.topic));
+    assert.deepStrictEqual([...topics], ['alpha'], 'the closed chunk must be single-topic');
+    assert.strictEqual(s.chunks[0].messages.length, 5);
+
+    // Hinted closes persist boundary ownership like size-based ones.
+    assert.strictEqual(s.chunkRecords.length, 1, 'hinted close must append a chunk record');
+    assert.deepStrictEqual(
+      s.chunkRecords[0].sourceIds,
+      s.chunks[0].messages.map((m) => m.id),
+      'record must own exactly the closed chunk\'s messages',
+    );
+    assert.strictEqual(s.chunks[0].recordId, s.chunkRecords[0].id);
+
+    await manager.close();
+  });
+
+  it('ignores a boundary before the minimum message count', async () => {
+    cleanup();
+    const strategy = new TopicBoundaryStrategy({
+      targetChunkTokens: 10_000,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+    });
+    const manager = await openManager(strategy);
+
+    // Only 3 alpha messages before the transition — under the 4-message
+    // minimum, the hint must not fire; with size-close unreachable the
+    // whole store stays an open frontier.
+    for (let i = 0; i < 3; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent',
+        [{ type: 'text', text: filler(20) }], { topic: 'alpha' });
+    }
+    for (let i = 0; i < 4; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent',
+        [{ type: 'text', text: filler(20) }], { topic: 'beta' });
+    }
+
+    rebuild(manager, strategy);
+    assert.strictEqual(internals(strategy).chunks.length, 0,
+      'no chunk may close: boundary was under-minimum, size target unreached');
+
+    await manager.close();
+  });
+
+  it('tool_use pairing outranks the hinted boundary', async () => {
+    cleanup();
+    const strategy = new TopicBoundaryStrategy({
+      targetChunkTokens: 10_000,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+    });
+    const manager = await openManager(strategy);
+
+    // alpha ends on a tool_use; its tool_result opens beta. The hint at the
+    // alpha→beta edge must be suppressed (closing there would strand the
+    // pair across chunks); the next hintable boundary (beta→gamma) closes a
+    // chunk containing BOTH topics with the pair intact.
+    for (let i = 0; i < 3; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent',
+        [{ type: 'text', text: filler(20) }], { topic: 'alpha' });
+    }
+    manager.addMessage('agent', [
+      { type: 'text', text: filler(10) },
+      { type: 'tool_use', id: 'A', name: 'fn', input: {} },
+    ] as ContentBlock[], { topic: 'alpha' });
+    manager.addMessage('user', [
+      { type: 'tool_result', toolUseId: 'A', content: 'res' },
+    ] as ContentBlock[], { topic: 'beta' });
+    for (let i = 0; i < 3; i++) {
+      manager.addMessage(i % 2 === 0 ? 'agent' : 'user',
+        [{ type: 'text', text: filler(20) }], { topic: 'beta' });
+    }
+    for (let i = 0; i < 4; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent',
+        [{ type: 'text', text: filler(20) }], { topic: 'gamma' });
+    }
+
+    rebuild(manager, strategy);
+    const s = internals(strategy);
+
+    assert.strictEqual(s.chunks.length, 1, 'one chunk should close at the beta→gamma edge');
+    const chunk = s.chunks[0];
+    assert.strictEqual(chunk.messages.length, 8, 'alpha + beta ride together (pair kept)');
+    const chunkTopics = new Set(chunk.messages.map((m) => m.metadata?.topic));
+    assert.deepStrictEqual([...chunkTopics].sort(), ['alpha', 'beta']);
+    const last = chunk.messages[chunk.messages.length - 1];
+    assert.ok(
+      !last.content.some((b) => b.type === 'tool_use'),
+      'closed chunk must not end on a tool_use',
+    );
+
+    await manager.close();
+  });
+});

--- a/test/long-context-saturation.test.ts
+++ b/test/long-context-saturation.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Saturation liveness — the regression gate for the 2026-08-03 production
+ * outage class (boter clerk, fail→wake→fail on `UncoveredDropError`).
+ *
+ * A long-lived agent's summary pyramid grows monotonically. The legacy
+ * hierarchical renderer emits head → summaries → middle → tail with no
+ * tail reservation and no way to shed summary mass, so at a fixed budget
+ * it eventually cannot afford its own recent window: newest-first
+ * eviction digs into the recent window, the evicted messages have no
+ * summary coverage (the recent window is excluded from the compressible
+ * zone), and under the fatal coverage invariant (76e95a0, v0.6.0) the
+ * compile refuses. The refusal is terminal — the host-side drain breaker
+ * kicks tick(), but compression is forbidden for exactly the span that
+ * was dropped. Long-lived agents belong on the adaptive path, which
+ * solves a frontier TO FIT the budget: tail reserved first, older
+ * history folding deeper until it fits.
+ *
+ * Pinned here:
+ *  1. adaptive + kv-stable stays live — zero refusals — across a workload
+ *     whose raw history is many multiples of the compile budget;
+ *  2. under pathological pressure, any refusal the adaptive path does
+ *     produce is the recoverable class (`OverBudgetError`, which the
+ *     drain breaker can act on), never `UncoveredDropError`.
+ *
+ * The hierarchical renderer's saturation refusal is documented behavior,
+ * deliberately not asserted: pinning brokenness would turn a future fix
+ * into a test failure.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { AutobiographicalStrategy } from '../src/index.js';
+import { generateWorkload } from './_harness/workload.js';
+import { runStrategyOnWorkload } from './_harness/strategy-runner.js';
+
+const UNCOVERED_SIGNATURE = /no summary covers/i;
+const OVERBUDGET_SIGNATURE = /exceed hard budget/i;
+
+function adaptiveStrategy(overrides: Record<string, unknown> = {}): AutobiographicalStrategy {
+  return new AutobiographicalStrategy({
+    adaptiveResolution: true,
+    foldingStrategy: 'kv-stable',
+    compressionModel: 'mock-compressor',
+    targetChunkTokens: 500,
+    headWindowTokens: 0,
+    recentWindowTokens: 2000,
+    ...overrides,
+  } as ConstructorParameters<typeof AutobiographicalStrategy>[0]);
+}
+
+describe('AutobiographicalStrategy: budget-saturation liveness (adaptive)', () => {
+  it('compiles every turn with raw history at several times the budget', async () => {
+    // ~400 turns × ~90 avg tokens ≈ 36k raw against an 11k select target:
+    // deep folding is mandatory well before the run ends. Tool-free on
+    // purpose: the harness compiles after EVERY message, including mid
+    // tool-cycle (assistant tool_use stored, tool_result not yet) — a moment
+    // real hosts never compile at — and the pairing trims then refuse the
+    // turn for reasons orthogonal to the budget geometry pinned here. Tool
+    // pairing has its own gates (tool-pairing-invariant, chunker-tool-boundary).
+    const workload = generateWorkload({
+      turns: 400,
+      avgUserTokens: 60,
+      avgAssistantTokens: 120,
+      toolCallProbability: 0,
+      seed: 20260803,
+    });
+
+    const result = await runStrategyOnWorkload(
+      () => adaptiveStrategy(),
+      workload,
+      {
+        label: 'saturation-live',
+        compileBudget: { maxTokens: 12_000, reserveForResponse: 1_000 },
+        compressor: (call) =>
+          `Recalled span ${call.callIndex}: routine exchange, nothing externally binding.`,
+      },
+    );
+
+    const failed = result.perTurn.filter((t) => t.compileError !== undefined);
+    assert.strictEqual(
+      result.compileErrors,
+      0,
+      `adaptive path refused ${result.compileErrors}/${result.perTurn.length} turns; ` +
+        `first: turn ${failed[0]?.turnIndex}: ${failed[0]?.compileError}`,
+    );
+  });
+
+  it('never refuses with UncoveredDropError, even under pathological pressure', async () => {
+    // Deliberately cruel geometry: a tiny budget with a proportionally large
+    // reserved tail and bloated summaries. Refusals are acceptable here —
+    // but every refusal must be the recoverable class. An uncovered drop
+    // means the renderer lost history without representation: the terminal,
+    // breaker-immune outage shape.
+    // Tool-free for the same reason as above.
+    const workload = generateWorkload({
+      turns: 300,
+      avgUserTokens: 80,
+      avgAssistantTokens: 160,
+      toolCallProbability: 0,
+      seed: 803,
+    });
+
+    const result = await runStrategyOnWorkload(
+      () => adaptiveStrategy({ recentWindowTokens: 1500, targetChunkTokens: 400 }),
+      workload,
+      {
+        label: 'saturation-pathological',
+        compileBudget: { maxTokens: 6_000, reserveForResponse: 1_000 },
+        // Bloated summaries: each recall pair costs a large slice of the
+        // budget, forcing merge pressure and, eventually, hard refusals.
+        compressor: (call) =>
+          `Recalled span ${call.callIndex}: ` + 'remembered detail, '.repeat(40),
+      },
+    );
+
+    const uncovered = result.perTurn.filter(
+      (t) => t.compileError !== undefined && UNCOVERED_SIGNATURE.test(t.compileError),
+    );
+    assert.strictEqual(
+      uncovered.length,
+      0,
+      `adaptive path produced ${uncovered.length} uncovered-drop refusal(s); ` +
+        `first: turn ${uncovered[0]?.turnIndex}: ${uncovered[0]?.compileError}`,
+    );
+
+    // Sanity on the signature itself: if refusals happened, they must be the
+    // over-budget class — a rewording of either error message would rot both
+    // regexes silently, so pin the one we expect to see.
+    const refusals = result.perTurn.filter((t) => t.compileError !== undefined);
+    for (const t of refusals) {
+      assert.ok(
+        OVERBUDGET_SIGNATURE.test(t.compileError!),
+        `turn ${t.turnIndex}: unexpected refusal class: ${t.compileError}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #51 (contribution policy) — its one docs commit appears here until #51 merges; merge #51 first and this collapses to one commit.

## What

1. **`chunkBoundaryHint(prev, next, currentChunk)`** — a protected seam consulted between adjacent frontier messages during chunking. A subclass with domain knowledge (chat-topic transitions) closes the running chunk early at a semantic boundary while riding the base chunker: hinted closes persist chunk records and respect the minimum-size and tool_use-pairing guards exactly like size-based closes. The close block is factored into a single closure so the two close sites cannot drift.
2. **Budget-saturation liveness gates** (`test/long-context-saturation.test.ts`) via the shared long-context harness: (a) adaptive + kv-stable compiles every turn of a tool-free workload whose raw history is several times the compile budget; (b) under pathological pressure (tiny budget, bloated summaries) any refusal must be the recoverable `OverBudgetError` class — never `UncoveredDropError`.
3. Two adaptive refusal sites (tail shortfall, newest-turn retention) now name their `stage` instead of reading as picker exhaustion with impossible arithmetic ("742 tokens still exceed hard budget 11220" — that message cost this investigation an hour).

## Why

2026-08-03 boter clerk outage: the frontdesk (hierarchical-renderer) agent saturated its fixed budget into a terminal `UncoveredDropError` fail→wake→fail loop — the AF drain breaker cannot help because compression is excluded from the recent window, exactly where the drops happen. The fix direction is moving frontdesk onto the adaptive path; this PR provides the seam it needs to keep topic-aware chunking without forking `rebuildChunks` (the fork also silently bypassed chunk-record persistence and the fail-closed orphan guard), plus the regression net that would have caught the outage class in CI.

The saturation workloads are deliberately tool-free: the harness compiles after every message, including mid tool-cycle (assistant `tool_use` stored, `tool_result` not yet) — a moment real hosts never compile at — and the pairing trims then refuse for reasons orthogonal to budget geometry. Tool pairing has its own gates.

## Notes

- `snapshot-cadence-retune` fails on main before this PR (expects a registration function that comes back `undefined`); untouched here.
- Suite: 448 pass / 1 pre-existing fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)