### PR TITLE
fix(deps): chronicle floor ^0.3.0 — un-red main CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@animalabs/context-manager",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@animalabs/context-manager",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@animalabs/chronicle": "^0.2.6",
+        "@animalabs/chronicle": "^0.3.0",
         "@animalabs/membrane": "^0.5.69"
       },
       "devDependencies": {
@@ -21,17 +21,10 @@
       }
     },
     "node_modules/@animalabs/chronicle": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.2.6.tgz",
-      "integrity": "sha512-+gbt2GR4SP8MnKxeqkJZf6oZn339fLiBtk6GHyBD/gHQ4e4eFqBpTaTd5eKycKBws0xWGcOqyiJFH4IdBkweUA==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "@animalabs/chronicle-darwin-arm64": "0.2.6",
-        "@animalabs/chronicle-darwin-x64": "0.2.6",
-        "@animalabs/chronicle-linux-arm64-gnu": "0.2.6",
-        "@animalabs/chronicle-linux-x64-gnu": "0.2.6",
-        "@animalabs/chronicle-win32-x64-msvc": "0.2.6"
-      }
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@animalabs/chronicle/-/chronicle-0.3.0.tgz",
+      "integrity": "sha512-6BBJ9pWb8AnuHTNJTU07Y6Wut3IvdgWFxsy05IdlWcEnR5W23dlaBlaeJq7gDc7TwX05HfsDC+QZFEc69G+s4Q==",
+      "license": "MIT"
     },
     "node_modules/@animalabs/membrane": {
       "version": "0.5.69",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "Anima Research",
   "license": "MIT",
   "dependencies": {
-    "@animalabs/chronicle": "^0.2.6",
+    "@animalabs/chronicle": "^0.3.0",
     "@animalabs/membrane": "^0.5.69"
   },
   "devDependencies": {


### PR DESCRIPTION
Main CI has been red since 2026-08-01: the snapshot-cadence-retune test asserts `JsStore.updateStateStrategy` (a chronicle 0.3.0 API) but package.json still declared `^0.2.6`, which semver never resolves to 0.3.0 — CI installs 0.2.x and the feature-detect assertion fails. chronicle 0.3.0 is published; this bumps the floor and the lockfile.

Full suite goes 441/441 green with this (verified on a clean `npm ci` worktree).

Labelled no-changelog: dependency-floor repair for an unreleased test, no consumer-visible behavior change. Merge before #51/#52 so the rest of the train inherits green CI.

Note for a follow-up: agent-framework/connectome-host declare chronicle `^0.2.x` — once CM releases with `^0.3.0` they'll carry a nested 0.3.0 for CM while creating stores with 0.2.x themselves. CM's retune path feature-detects, so this skew is safe, but the ecosystem-wide bump should follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)