### PR TITLE
Solver observability: attribute every compile to the solver that planned it

### DIFF
--- a/src/adaptive/picker.ts
+++ b/src/adaptive/picker.ts
@@ -267,6 +267,14 @@ export function accountFrontier(
 export class Picker {
   constructor(private readonly solver: FoldingSolver) {}
 
+  /** Name of the solver this picker runs — surfaced so every compile can be
+   *  attributed to the policy that actually planned it (solver observability:
+   *  a config clobber that silently downgrades kv-stable → flat-profile is
+   *  invisible without this). */
+  get solverName(): string {
+    return this.solver.name;
+  }
+
   run(inputs: PickerInputs, budget: FoldingBudget): PickerResult {
     const solution = this.solver.solve(inputs, budget);
     const { frontier, produced } = solution;

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1028,6 +1028,9 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
   /** Lazy picker instance, built from config.foldingStrategy. */
   private _adaptivePicker: Picker | null = null;
+  /** foldingStrategy as resolved at construction — the drift baseline for
+   *  [picker-config-drift]. */
+  private _constructedFoldingStrategy: AutobiographicalConfig['foldingStrategy'];
 
   /** A future usable window the KV-stable controller is preparing while the
    * caller keeps compiling against its current hard window. */
@@ -1057,6 +1060,12 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       this.config.compressionSlackRatio ??= 0.1;
       this.config.speculativeProduction ??= true;
     }
+    // The solver committed to at construction. buildPicker compares the live
+    // config against this on every compile: a runtime mutation (e.g. an
+    // override merge carrying `foldingStrategy: undefined`) silently swaps
+    // the solver — and with it the entire cache-stability policy — for that
+    // compile. That drift must be LOUD (see [picker-config-drift]).
+    this._constructedFoldingStrategy = this.config.foldingStrategy;
   }
   /**
    * Explicit operator escape hatch. A retry remains canonical-first; clearing
@@ -1158,8 +1167,18 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const savedPlannedMeta = this._plannedMeta;
     this._lastPreview = undefined;
     try {
-      if (overrides && Object.keys(overrides).length > 0) {
-        this.config = { ...savedConfig, ...overrides };
+      // Drop explicit undefined/null overrides BEFORE spreading: a spread
+      // with `foldingStrategy: undefined` ERASES the live key and silently
+      // downgrades the solver to flat-profile for this preview's compile
+      // (JSON-driven callers — fleet hub, panel forms — can produce exactly
+      // that shape). Absence is the only way to mean "keep the live value".
+      const cleaned = overrides
+        ? Object.fromEntries(
+            Object.entries(overrides).filter(([, v]) => v !== undefined && v !== null),
+          )
+        : undefined;
+      if (cleaned && Object.keys(cleaned).length > 0) {
+        this.config = { ...savedConfig, ...cleaned };
         // Both memoize config-derived values, so a swapped config must not see
         // a cache built under the old one.
         this._adaptivePicker = null;
@@ -4303,7 +4322,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   private _emittedSummaryIds: Set<string> = new Set();
   /** The picker's projected total for this compile (planner side). */
   private _plannedTokens: number | null = null;
-  private _plannedMeta: { budgetMet: boolean; exhausted: boolean; moves: number } | null = null;
+  private _plannedMeta: { budgetMet: boolean; exhausted: boolean; moves: number; solver: string } | null = null;
 
   protected rsSummary(level: number, tokens: number, id?: string): void {
     if (id) this._emittedSummaryIds.add(id);
@@ -4349,6 +4368,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         budgetMet: m?.budgetMet ?? false,
         exhausted: m?.exhausted ?? false,
         moves: m?.moves ?? 0,
+        ...(m?.solver !== undefined ? { solver: m.solver } : {}),
       };
       // Loud only when the emitter OVERRUNS the plan — that is the direction
       // that costs the tail. Under-spend is harmless slack.
@@ -4356,7 +4376,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const line =
         `[plan-vs-actual] planned=${planned} actual=${actual} delta=${delta >= 0 ? '+' : ''}${delta}` +
         ` (${pct >= 0 ? '+' : ''}${pct.toFixed(1)}%) budgetMet=${m?.budgetMet} exhausted=${m?.exhausted}` +
-        ` moves=${m?.moves}`;
+        ` moves=${m?.moves} solver=${m?.solver}`;
       if (loud) console.warn(`${line} — emitter overran the plan; the overrun is paid by the recent window`);
       else console.error(line);
     }
@@ -6751,6 +6771,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       budgetMet: result.budgetMet,
       exhausted: result.exhausted,
       moves: result.moves,
+      solver: picker.solverName,
     };
 
     // Every trust-region override is loud (design §13.4) — silence was half
@@ -7472,6 +7493,21 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     inputs: PickerInputs,
     preparedBudget?: { totalBudget: number; targetBudget: number },
   ): Picker {
+    // Drift alarm: the live config must still name the solver chosen at
+    // construction. Nothing legitimate rewrites foldingStrategy at runtime —
+    // a mismatch means an override merge (or other mutation) clobbered it,
+    // and THIS compile is about to run under the wrong cache policy. The
+    // 2026-08-07 fable investigation found exactly one such compile
+    // ([picker-unrealizable] solver=flat-profile in a kv-stable agent) with
+    // no way to attribute it; this line is the attribution.
+    if (this.config.foldingStrategy !== this._constructedFoldingStrategy) {
+      console.error(
+        `[picker-config-drift] foldingStrategy=${JSON.stringify(this.config.foldingStrategy)} ` +
+          `differs from constructed=${JSON.stringify(this._constructedFoldingStrategy)} — ` +
+          `a runtime mutation clobbered the solver choice; this compile runs the wrong solver`,
+        new Error('picker-config-drift stack').stack,
+      );
+    }
     if (this.config.foldingStrategy === 'kv-stable') {
       const strategy = new KvStableStrategy({
         reachTokens: preparedBudget === undefined

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -424,6 +424,10 @@ export interface RenderStats {
     budgetMet: boolean;
     exhausted: boolean;
     moves: number;
+    /** Name of the fold solver that planned this compile (e.g. 'kv-stable',
+     *  'flat-profile'). Surfaces the policy actually in force — a config
+     *  clobber that silently downgrades the solver is invisible without it. */
+    solver?: string;
   };
 }
 

--- a/test/dry-run-preview.test.ts
+++ b/test/dry-run-preview.test.ts
@@ -24,6 +24,7 @@ import { rmSync, existsSync } from 'node:fs';
 import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
 import type { ContentBlock } from '@animalabs/membrane';
 import type { ProduceRequest } from '../src/adaptive/folding-strategy.js';
+import type { Picker, PickerInputs } from '../src/adaptive/picker.js';
 
 const TEST_STORE_PATH = './test-dry-run-preview';
 
@@ -39,6 +40,17 @@ function textBlock(text: string): ContentBlock[] {
 class SpyStrategy extends AutobiographicalStrategy {
   producedCalls = 0;
   persistCalls = 0;
+  /** Solver name of every picker built — attribution for the clobber test. */
+  pickerSolverNames: string[] = [];
+
+  protected buildPicker(
+    inputs: PickerInputs,
+    preparedBudget?: { totalBudget: number; targetBudget: number },
+  ): Picker {
+    const picker = super.buildPicker(inputs, preparedBudget);
+    this.pickerSolverNames.push(picker.solverName);
+    return picker;
+  }
 
   protected handleProducedOps(ops: readonly ProduceRequest[], opts?: { speculative?: boolean }): void {
     this.producedCalls++;
@@ -162,6 +174,46 @@ describe('AutobiographicalStrategy — dry-run preview', () => {
 
     assert.strictEqual(strategy.configTail(), tailBefore, 'recentWindowTokens must be restored');
     assert.strictEqual(strategy.configChunk(), chunkBefore, 'targetChunkTokens must be restored');
+  });
+
+  it('drops explicit undefined/null overrides instead of clobbering live keys', async () => {
+    const strategy = makeStrategy({ foldingStrategy: 'kv-stable' });
+    const manager = await ContextManager.open({ path: TEST_STORE_PATH, strategy });
+    addConversation(manager);
+    await manager.compile({ maxTokens: 100_000, reserveForResponse: 200 });
+
+    // The live compile must both run kv-stable and REPORT it (planVsActual
+    // is the fleet's only from-outside solver check, via /debug/context/makeup).
+    const stats = (strategy as unknown as {
+      getRenderStats: (s: unknown) => { planVsActual?: { solver?: string } } | null;
+    }).getRenderStats(undefined);
+    assert.strictEqual(
+      stats?.planVsActual?.solver, 'kv-stable',
+      'planVsActual must expose the solver that planned the compile',
+    );
+
+    // A JSON-driven caller (fleet hub, panel form) can serialize absent form
+    // fields as explicit undefined/null. Spreading those into the config would
+    // ERASE the live foldingStrategy and silently run this preview's compile
+    // on flat-profile — the exact drift the 2026-08-07 fable investigation
+    // could not attribute. They must be dropped, not spread.
+    strategy.pickerSolverNames.length = 0;
+    const preview = manager.previewContext(
+      { maxTokens: 100_000, reserveForResponse: 200 },
+      {
+        foldingStrategy: undefined,
+        compressionSlackRatio: null as unknown as number,
+        targetChunkTokens: 777,
+      },
+    );
+    assert.ok(preview, 'preview with sparse overrides must succeed');
+    assert.ok(strategy.pickerSolverNames.length > 0, 'preview must have built a picker');
+    for (const name of strategy.pickerSolverNames) {
+      assert.strictEqual(
+        name, 'kv-stable',
+        'undefined/null overrides must not downgrade the solver for the previewed compile',
+      );
+    }
   });
 
   it('a larger tail override raises the previewed tail cost', async () => {


### PR DESCRIPTION
## Why

The 2026-08-07 Fable cost investigation hit a wall: a `[picker-unrealizable] solver=flat-profile` compile fired inside an agent whose construction verifiably resolves to `kv-stable` (verified by running her fkm+recipe through `buildFrameworkStrategy` on her box). Four hours of archaeology could not attribute it — nothing logs which solver planned a given compile.

A silent solver swap is not cosmetic: it replaces the whole cache-stability policy for that compile. The speculative producer and live compile then disagree about frontier geometry → folds become unrealizable (`the frontier must be realizable by contract`) → the agent idles pinned over budget (fable: 397k live vs 300k budget, `budgetMet: false` chronically) paying full-window cache rewrites (~$10/rotation at fable pricing, every ~7 warm rounds — the dominant line item in her ledger).

## What

1. **`Picker.solverName`** + `solver=` appended to every `[plan-vs-actual]` line and to `RenderStats.planVsActual` — the live solver is now checkable per compile from logs and from `/debug/context/makeup`, fleet-wide, zero instrumentation.
2. **`[picker-config-drift]`** — `buildPicker` compares live `foldingStrategy` against the value captured at construction; any mismatch logs loudly with a stack. Nothing legitimate rewrites the solver at runtime, so a mismatch is a clobber caught red-handed.
3. **Preview override hardening** — `previewContext` drops explicit `undefined`/`null` override values before spreading. JSON-driven callers (fleet hub, panel forms) serializing absent fields would otherwise erase live config keys — `foldingStrategy: undefined` silently downgrades that preview's compile to flat-profile. This is the one surviving candidate for the unattributed fable compile.

## Tests

- New: `drops explicit undefined/null overrides instead of clobbering live keys` (asserts solver stays `kv-stable` through a sparse-override preview, and that `planVsActual.solver` is reported).
- Full suite: 4 pre-existing failures on pristine main (issue-#56 kv-stable demand family, awaiting uncommitted WIP), verified unchanged before/after — no new failures. Verified the new subtest actually executed.

## Follow-ups (separate PRs)
- Band retune (fold cadence 7 → 30-40 rounds) + explicit `foldingStrategy` pins in fleet recipes.
- `PRICE` correction in kv-control (1h cacheWrite = 2.0, and charge writes in the billed expression) — behavior-changing, wants replay validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)