### PR TITLE
fix(kv-stable): demand-side L1 production under escalation (#56)

### DIFF
--- a/docs/adaptive-resolution-design.md
+++ b/docs/adaptive-resolution-design.md
@@ -790,6 +790,25 @@ Every override is loud: the plan reports `override: 'infeasible' | 'quality-gap'
 | 'bootstrap'` plus the exact perturbation, and the strategy layer logs a
 `[kv-escalation]` line. Silence was half of the incident.
 
+**Demand-side production under escalation (issue #56, 2026-08-06).** The
+solver never *speculatively* pre-produces — deeper folding than has been
+produced stays the pre-producer's job — but when the plan **escalates**
+(even full folding exceeds W) while foldable chunks have no L1 coverage at
+all, `KvStableStrategy.solve` emits level-1 `ProduceRequest`s over the
+contiguous uncovered runs (skipping the flat zone, pins, and locked chunks).
+This is the only route into the strategy layer's demand path
+(`handleProducedOps` → `enqueueL1ForRange` → `_demandedL1Chunks`), which is
+what overrides the `l1HoldbackChunks` window. Without it, tight operating
+points — where the budget wall lands while the only uncompressed material is
+the unclosed trailing span plus the held-back newest closed chunk — wedged
+permanently: empty speculative queue, no way to raise demand, every compile
+re-escalating infeasible (the L1-holdback deadlock; external repro at
+budgets 14–26k). A produce op still never authorizes an inference — the
+escalated compile hard-fails as before — but recovery now needs only the
+production drain, not config surgery. A range whose tail ends in the
+unclosed trailing span (not yet a chunk) resolves "through the newest closed
+chunk" at the consumer, so the whole backlog is demanded in one compile.
+
 ### 13.3 Salience as a coefficient (not a cap)
 
 `foldDepthCap`'s log-age banding survives only as the *shape prior* inside the

--- a/scripts/replay-strategy.ts
+++ b/scripts/replay-strategy.ts
@@ -196,9 +196,12 @@ async function main() {
 
   // 2×2: folding policy (flat / kv-stable) × marker placement (strategy / ideal).
   // Isolates the dominant lever (markers) from the folding-policy effect.
+  // --kv-only skips the flat-profile variants — they are invariant to
+  // --reach, so parameter sweeps only need them once (in a full-grid run).
+  const kvOnly = args.includes('--kv-only');
   const grid: Record<string, TraceResult> = {};
   for (const markerMode of ['strategy', 'ideal'] as const) {
-    for (const useKvStable of [false, true]) {
+    for (const useKvStable of kvOnly ? [true] : [false, true]) {
       const r = await runVariant({ name, useKvStable, reachTokens, markerMode, ...common });
       const tag = `${useKvStable ? 'kv-stable' : 'flat-profile'} · ${markerMode}-markers`;
       grid[`${useKvStable ? 'kv' : 'flat'}_${markerMode}`] = r;
@@ -210,14 +213,16 @@ async function main() {
   const meta = { name, chunks: chunks.length, rawTotal, budgetTokens, medianSummaryTokens, stride, reachTokens: reachTokens ?? null };
   // The viewer compares the two policies under the better (ideal) marker placement.
   writeFileSync(`${outDir}/${name}-kv-trace.json`, JSON.stringify({ meta, ...grid.kv_ideal }));
-  writeFileSync(`${outDir}/${name}-flat-trace.json`, JSON.stringify({ meta, ...grid.flat_ideal }));
+  if (grid.flat_ideal) writeFileSync(`${outDir}/${name}-flat-trace.json`, JSON.stringify({ meta, ...grid.flat_ideal }));
 
   console.log(`\nMarker placement is the dominant lever:`);
-  console.log(`  flat:  strategy-markers ${(grid.flat_strategy.overallHitRate * 100).toFixed(1)}% → ideal-markers ${(grid.flat_ideal.overallHitRate * 100).toFixed(1)}% hit`);
+  if (grid.flat_strategy) console.log(`  flat:  strategy-markers ${(grid.flat_strategy.overallHitRate * 100).toFixed(1)}% → ideal-markers ${(grid.flat_ideal.overallHitRate * 100).toFixed(1)}% hit`);
   console.log(`  kv:    strategy-markers ${(grid.kv_strategy.overallHitRate * 100).toFixed(1)}% → ideal-markers ${(grid.kv_ideal.overallHitRate * 100).toFixed(1)}% hit`);
-  const dRe = grid.flat_ideal.totalRecomputed - grid.kv_ideal.totalRecomputed;
-  const dMax = grid.flat_ideal.maxPerturbation - grid.kv_ideal.maxPerturbation;
-  console.log(`Under ideal markers, kv-stable vs flat: recompute ${dRe >= 0 ? '−' : '+'}${fmt(Math.abs(dRe))}, max-perturb ${dMax >= 0 ? '−' : '+'}${fmt(Math.abs(dMax))}`);
+  if (grid.flat_ideal) {
+    const dRe = grid.flat_ideal.totalRecomputed - grid.kv_ideal.totalRecomputed;
+    const dMax = grid.flat_ideal.maxPerturbation - grid.kv_ideal.maxPerturbation;
+    console.log(`Under ideal markers, kv-stable vs flat: recompute ${dRe >= 0 ? '−' : '+'}${fmt(Math.abs(dRe))}, max-perturb ${dMax >= 0 ? '−' : '+'}${fmt(Math.abs(dMax))}`);
+  }
   console.log(`wrote ${outDir}/${name}-{kv,flat}-trace.json`);
 }
 

--- a/src/adaptive/strategies/kv-stable.ts
+++ b/src/adaptive/strategies/kv-stable.ts
@@ -16,9 +16,15 @@
  * the ideal within P, amortizing bigger repairs via suffix adoption, and
  * exceeding P only with a recorded override. There is no emergency path.
  *
- * It does not emit produce requests — deeper folding than has been produced
- * is the speculative pre-producer's job; the controller only targets levels
- * whose summaries already exist. Deterministic.
+ * It does not SPECULATIVELY emit produce requests — deeper folding than has
+ * been produced is the speculative pre-producer's job; the controller only
+ * targets levels whose summaries already exist. The one exception is DEMAND
+ * under escalation (issue #56): when even full folding exceeds the hard wall
+ * W while foldable chunks have no L1 coverage at all, production is the only
+ * remaining lever, and the caller's demand path (`handleProducedOps` →
+ * `enqueueL1ForRange` → the L1-holdback exemption) is reachable only through
+ * produce ops — so the solve emits L1 requests for the uncovered ranges.
+ * Deterministic.
  *
  * History: this used to walk the plan into the picker one group-atomic
  * raise/lower op at a time. Group ops cannot express a frontier that cuts
@@ -34,6 +40,7 @@ import type {
   FoldingSolution,
   FoldingBudget,
   ChunkId,
+  ProduceRequest,
 } from '../folding-strategy.js';
 import type { PickerInputs } from '../picker.js';
 import { SummaryTree } from '../summary-tree.js';
@@ -154,9 +161,45 @@ export class KvStableStrategy implements FoldingSolver {
     });
     this._lastPlan = plan;
     this._lastTarget = plan.resolutions;
+
+    // DEMAND-SIDE PRODUCTION (issue #56). Speculative pre-production stays the
+    // pre-producer's job — but when even full folding exceeds the hard wall W
+    // (plan.escalated) while foldable chunks have no L1 at all, producing
+    // those L1s is the only lever left, and the caller's demand path
+    // (`handleProducedOps` → `enqueueL1ForRange` → `_demandedL1Chunks`) fires
+    // only on produce ops. Emitting none wedged tight operating points
+    // PERMANENTLY: the L1 holdback filter kept the newest closed chunk(s) out
+    // of the speculative queue, demand could never be raised to override the
+    // holdback, and every compile re-escalated infeasible (the L1-holdback
+    // deadlock — external repro at budgets 14–26k). Contiguous uncovered runs
+    // coalesce into one request each; the consumer maps message ranges back
+    // onto closed chunks and dedupes against its queue, so re-emission on
+    // subsequent escalated compiles is convergent, and a range covering only
+    // the unclosed trailing span (not yet a chunk) is skipped harmlessly.
+    const produced: ProduceRequest[] = [];
+    if (plan.escalated) {
+      const bySequence = [...inputs.chunks].sort((a, b) => a.sequence - b.sequence);
+      let run: { first: ChunkId; last: ChunkId } | null = null;
+      const flush = (): void => {
+        if (run) produced.push({ level: 1, range: { firstChunkId: run.first, lastChunkId: run.last } });
+        run = null;
+      };
+      for (const c of bySequence) {
+        // Uncovered AND foldable: no L1 lineage, not force-raw (head/tail/
+        // pins — incl. pin-at-k clamped to raw for lack of summaries, which
+        // lands in rawZone above), not frozen (locked keeps its resolution,
+        // so a produced L1 could never be rendered anyway).
+        const uncovered = !c.l1Id && !rawZone.has(c.id) && !frozen.has(c.id);
+        if (!uncovered) { flush(); continue; }
+        if (run) run.last = c.id;
+        else run = { first: c.id, last: c.id };
+      }
+      flush();
+    }
+
     return {
       frontier: plan.resolutions,
-      produced: [],
+      produced,
       // Kv-stable exhaustion is the ESCALATED state only: even full folding
       // exceeds the hard wall W. A dead-band hold above the soft target is
       // the designed steady state, not exhaustion — see


### PR DESCRIPTION
Closes #56.

Lands the implementation for the `kv-stable demand (issue #56)` tests **already committed on main** — they were red on main because the producer side was missing.

## The defect

`KvStableStrategy.solve` returned `produced: []` unconditionally, so under kv-stable the demand path (`handleProducedOps` → `enqueueL1ForRange` → `_demandedL1Chunks`) was unreachable. At tight operating points the wall lands while the only uncompressed material is the unclosed trailing span plus the held-back newest closed chunk → speculative queue empty, demand never raisable to override `l1HoldbackChunks`, every compile re-escalates infeasible **permanently**. Recovery needed config surgery.

## The change

When `plan.escalated` (even the fully-folded ideal exceeds the hard wall W) and foldable chunks have no L1 coverage, emit level-1 `ProduceRequest`s over contiguous uncovered runs — skipping flat zone, pins and locked chunks. Speculative pre-production stays the pre-producer's job: **a feasible wall still emits nothing.**

A produce op never authorizes an inference. The escalated compile still hard-fails with `OverBudgetError` (ops enqueue at `selectAdaptive` before the throw, and never on a dry run). What changes is that recovery needs only the production drain.

## Verification

| check | result |
|---|---|
| trigger is true infeasibility | `escalated = ideal.tokens > windowTokens`; every other `ControlPlan` return path sets `escalated: false` and is guarded by `<= windowTokens` |
| demand raised before the throw | `handleProducedOps` precedes the `OverBudgetError` throw; `!dryRun` guarded, so previews never mint |
| protections | head/tail/pins → `rawZone`; locked → `frozen`; pin-at-k lacking summaries clamps into `rawZone`; covered excluded via `l1Id` (with L1 `sourceIds` coverage fallback) |
| convergence | `enqueueL1ForRange` skips compressed chunks and queue duplicates; `_demandedL1Chunks` is a Set — re-emission idempotent, no mint storm |
| ranges | `ChunkId = MessageId`; picker entries are per-message and the index space is gapless, so sorted runs are genuinely contiguous |
| fails on clean main | 3 committed unit tests + the e2e demand assertion fail at `fee8dd6`, pass here |
| suite | 466 pass / 3 fail; the same 3 fail identically on clean main (5000 ms harness timeouts + recall-curve), typecheck clean |

These exact bytes have been running on Princess since 2026-08-08T20:38:03Z (receipt `princess-cm/deploy-receipts/20260808T2038Z-cm-wip.*`); the commit gives them a lineage identity without a restart.

Code by @antra-tess; reviewed and landed unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)