### PR TITLE
fix(cache): place the stable-prefix breakpoint at the measured boundary

### DIFF
--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -7322,12 +7322,38 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   }
 
   /**
-   * Place up to four `cache_control` breakpoints across the final ordered
-   * entries: the head/system boundary, the end of the folded history (the
-   * stable prefix that persists turn-to-turn — the most valuable), a mid-history
-   * seam, and the very end (for pure-append reuse). Mirrors `placeMarkers` in
-   * the adaptive layer but operates on emitted entries. Idempotent; clears any
-   * pre-existing markers first.
+   * Previous compile's per-entry cache identities (participant + content
+   * bytes), used to find the measured stable-prefix boundary. In-memory only:
+   * after a restart the first compile falls back to seam placement.
+   */
+  protected _prevCacheKeys?: string[];
+
+  /**
+   * Place up to three message-level `cache_control` breakpoints across the
+   * final ordered entries: the head/system boundary, the MEASURED stable
+   * prefix boundary, and the very end (pure-append reuse).
+   *
+   * The stable-prefix mark used to sit at the folded-history/tail seam
+   * (`historyEnd`) on the assumption that the folded region is stable
+   * turn-to-turn. Measured on mythos llm-calls 2026-08-13..17 that assumption
+   * fails ~1.4×/hour in steady state: fold rotations rewrite the folded
+   * region ABOVE the seam, and a seam marker then performs identically to no
+   * mid marker at all (priced replay over logged bytes: seam ≈ end-only;
+   * divergence-aligned ≈ −10%). So: diff this compile's entries against the
+   * previous compile's (by content identity — bytes are what the provider
+   * hashes) and mark the last entry of the SURVIVING prefix instead. In
+   * steady state (append-only) the boundary degrades gracefully to the seam;
+   * after a rotation it drops to the deepest byte-stable point, so subsequent
+   * requests re-read everything above the churn instead of re-writing it.
+   * See docs/unified-solve-design.md §9.2b.
+   *
+   * The Anthropic limit is 4 cache_control blocks per request INCLUDING the
+   * system block, which membrane marks whenever prompt caching is on — so
+   * message-level markers must never exceed 3 (Rhys, 2026-07-26: "A maximum
+   * of 4 blocks with cache_control may be provided. Found 5."). Deliberately
+   * NOT fixed by stripping in membrane — silently dropped markers are
+   * silently broken caching; the supplier stays within the global budget.
+   * Idempotent; clears any pre-existing markers first.
    */
   protected placeCacheMarkers(
     entries: ContextEntry[],
@@ -7350,27 +7376,26 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     }
     const historyEnd = firstTail - 1; // last middle (folded-history) entry
 
-    const marks = new Set<number>();
-    if (lastHead >= 0) marks.add(lastHead);                       // system / head block
-    if (historyEnd > lastHead) marks.add(historyEnd);            // stable folded prefix (the big one)
-    if (historyEnd - lastHead > 2) marks.add(lastHead + Math.floor((historyEnd - lastHead) / 2)); // mid-history
-    marks.add(n - 1);                                            // end → pure-append reuse
-
-    // The Anthropic limit is 4 cache_control blocks per request INCLUDING the
-    // system block, which membrane marks whenever prompt caching is on. So
-    // message-level markers must never exceed 3 — with all four seams placed
-    // (possible only once folds exist; pre-fold only 2 seams materialize) the
-    // request hard-400s: "A maximum of 4 blocks with cache_control may be
-    // provided. Found 5." (Rhys, 2026-07-26 — his first fold-active compile.)
-    // Drop the mid-history seam first: head and folded-prefix markers protect
-    // the expensive stable prefixes and the end marker buys pure-append
-    // reuse; the mid seam is the cheapest to lose. Deliberately NOT fixed by
-    // stripping in membrane — silently dropped markers are silently broken
-    // caching, which is an invisible-cost bug; the supplier stays within the
-    // global budget instead.
-    if (marks.size > 3) {
-      marks.delete(lastHead + Math.floor((historyEnd - lastHead) / 2));
+    // Measured stable prefix: first index where this compile's entry bytes
+    // diverge from the previous compile's. No previous compile → whole window
+    // counts as stable (seam placement, the old behavior).
+    const keys = entries.map(
+      (e) => `${e.participant} ${JSON.stringify(e.content)}`,
+    );
+    let firstDiff = n;
+    const prev = this._prevCacheKeys;
+    if (prev) {
+      let i = 0;
+      while (i < n && i < prev.length && keys[i] === prev[i]) i++;
+      firstDiff = i;
     }
+    this._prevCacheKeys = keys;
+    const stableEnd = Math.min(historyEnd, firstDiff - 1);
+
+    const marks = new Set<number>();
+    if (lastHead >= 0) marks.add(lastHead);            // system / head block
+    if (stableEnd > lastHead) marks.add(stableEnd);    // measured stable prefix (the big one)
+    marks.add(n - 1);                                  // end → pure-append reuse
 
     for (const idx of marks) if (idx >= 0 && idx < n) entries[idx].cacheMarker = true;
   }

--- a/test/cache-marker-stable-prefix.test.ts
+++ b/test/cache-marker-stable-prefix.test.ts
@@ -1,0 +1,95 @@
+/**
+ * placeCacheMarkers — measured-stable-prefix placement (2026-08-16).
+ *
+ * Load-bearing properties:
+ *  - first compile (no previous) degrades to seam placement: {head, historyEnd, end};
+ *  - append-only compile keeps the seam marker (stable prefix = whole previous window);
+ *  - a fold rotation that rewrites the middle drops the marker to the last
+ *    byte-surviving entry, NOT the seam — the seam assumption is the measured
+ *    failure (mythos llm-calls 2026-08-13..17: ~1.4 deep rewrites/hour);
+ *  - total rewrite places no stable-prefix marker and does not crash;
+ *  - never more than 3 message-level markers (Anthropic 4-block limit incl. system).
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AutobiographicalStrategy } from '../src/strategies/autobiographical.js';
+import type { ContextEntry } from '../src/types/context.js';
+
+class Exposed extends AutobiographicalStrategy {
+  place(entries: ContextEntry[], head: Set<string>, tail: Set<string>): void {
+    this.placeCacheMarkers(entries, head, tail);
+  }
+}
+
+function entry(id: string, text: string): ContextEntry {
+  return {
+    sourceMessageId: id,
+    participant: 'p',
+    content: [{ type: 'text', text }],
+  } as ContextEntry;
+}
+const marksOf = (es: ContextEntry[]) =>
+  es.map((e, i) => (e.cacheMarker ? i : -1)).filter((i) => i >= 0);
+
+function fixture() {
+  // head: h0..h1, middle (folded): m0..m5, tail: t0..t2
+  const es = [
+    entry('h0', 'sys-a'), entry('h1', 'sys-b'),
+    entry('m0', 'fold-0'), entry('m1', 'fold-1'), entry('m2', 'fold-2'),
+    entry('m3', 'fold-3'), entry('m4', 'fold-4'), entry('m5', 'fold-5'),
+    entry('t0', 'raw-0'), entry('t1', 'raw-1'), entry('t2', 'raw-2'),
+  ];
+  const head = new Set(['h0', 'h1']);
+  const tail = new Set(['t0', 't1', 't2']);
+  return { es, head, tail };
+}
+
+test('first compile: seam placement {head, historyEnd, end}', () => {
+  const s = new Exposed({});
+  const { es, head, tail } = fixture();
+  s.place(es, head, tail);
+  assert.deepEqual(marksOf(es), [1, 7, 10]); // lastHead=1, historyEnd=7, end=10
+});
+
+test('append-only compile keeps the seam marker', () => {
+  const s = new Exposed({});
+  const a = fixture();
+  s.place(a.es, a.head, a.tail);
+  const b = fixture();
+  b.es.push(entry('t3', 'raw-3'));
+  b.tail.add('t3');
+  s.place(b.es, b.head, b.tail);
+  assert.deepEqual(marksOf(b.es), [1, 7, 11]);
+});
+
+test('rotation drops the marker to the surviving prefix, not the seam', () => {
+  const s = new Exposed({});
+  const a = fixture();
+  s.place(a.es, a.head, a.tail);
+  const b = fixture();
+  b.es[4] = entry('m2b', 'fold-2-REWRITTEN'); // divergence at index 4
+  s.place(b.es, b.head, b.tail);
+  assert.deepEqual(marksOf(b.es), [1, 3, 10]); // stableEnd = 3, not seam 7
+});
+
+test('total rewrite: no stable-prefix marker, no crash', () => {
+  const s = new Exposed({});
+  const a = fixture();
+  s.place(a.es, a.head, a.tail);
+  const b = fixture();
+  for (let i = 0; i < b.es.length; i++) b.es[i] = entry(`x${i}`, `new-${i}`);
+  s.place(b.es, new Set(), new Set());
+  assert.deepEqual(marksOf(b.es), [b.es.length - 1]); // end only
+});
+
+test('never more than 3 message-level markers', () => {
+  const s = new Exposed({});
+  for (let round = 0; round < 4; round++) {
+    const { es, head, tail } = fixture();
+    if (round % 2) es[3] = entry(`m1-${round}`, `churn-${round}`);
+    s.place(es, head, tail);
+    assert.ok(marksOf(es).length <= 3, `round ${round}: ${marksOf(es)}`);
+  }
+});


### PR DESCRIPTION
## What

`placeCacheMarkers` puts its most valuable `cache_control` breakpoint at the folded-history/tail seam, on the assumption that the folded region above the seam is byte-stable turn-to-turn. That assumption fails in production: this PR moves the marker to the **measured** stable-prefix boundary — the last entry that survived the compile-to-compile diff — clamped to the seam.

## Why (measured on mythos, llm-calls 2026-08-13..17)

- Fold rotations rewrite the region **above** the seam ~1.4×/hour in steady state (not storm-correlated: 110 deep rewrites across 48 of 77 hours, 5 refusal-linked).
- The rewrites are positional, not content: 108/113 deep rewrites are ≥93% byte-identical messages shifted by a small front edit (summary swap / merge landing) — so everything downstream re-bills as cache-write at 1.25× despite being unchanged bytes.
- Consequence: the current seam marker performs **identically to having no mid marker at all**. Priced replay over the actual logged request bytes, billed basis (pre-output refusals excluded per Anthropic billing semantics): as-logged marks 118.9M units ≈ end-only 115.9M; divergence-aligned **101.9M (−14% in-sim)**. Claimed conservatively as **~10% of input spend**, since the simulator validates ~24% pessimistic against actual billing (Anthropic's real prefix matching recovers more than the model credits).

Analysis methodology and the wider context live in `docs/unified-solve-design.md` §9.2b (draft, untracked).

## How

- Keep a per-strategy `_prevCacheKeys` (participant + serialized content — the bytes the provider hashes) from the previous compile.
- On each compile, diff → first divergence index → mark `min(historyEnd, firstDiff − 1)` instead of `historyEnd`.
- Marker set stays `{head, stable-prefix, end}`, ≤3 message-level marks (the 4-block-limit lesson, Rhys 2026-07-26, preserved in the comment).
- The mid-history seam marker (which the 4-marker budget rule was already dropping whenever all seams materialized) is removed outright.

## Properties / risk

- **Append-only compiles produce byte-identical placement to today's** — steady state is unchanged.
- After a rotation the marker drops to the true surviving boundary, so subsequent requests re-read the stable prefix at 0.1× instead of re-writing at 1.25×. This also makes the kv-solver's own `PRICE.cacheRead = 0.1` assumption realizable — reach pacing currently prices re-reads the marker placement can't deliver.
- `_prevCacheKeys` is in-memory only: first compile after restart falls back to seam placement (old behavior). Moving a marker never invalidates existing cache entries — placement only affects where writes happen — so the failure mode is bounded at "no better than today", never worse.
- Cost: one `JSON.stringify` pass over rendered entries per compile (~ms against 5–8s compiles).

## Tests

- New `test/cache-marker-stable-prefix.test.ts` (5): seam placement on first compile; append keeps seam; rotation drops marker to surviving prefix; total-rewrite no-crash; ≤3 markers invariant.
- Full suite on this branch (rebased on current main): **474/474 pass**.

## Deploy notes

- Fleet runs cm from local checkouts and **loads `dist/` under fkm+bun** — deploy = pull + `npm run build` + restart.
- Suggest mythos first (the measured case), then verify with the before/after instrument: `~/replay-scratch/waste.py` on the box reproduces the baseline (billed basis); expect the partial-rewrite band and post-rotation recovery to convert writes→reads over a few days of logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)