### PR TITLE
fix(merge): level-scale the wide-span quarantine and make exclusions loud

### DIFF
--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -5673,10 +5673,26 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * Rules: order candidates by live source position; break runs where the
    * positional gap exceeds `mergeContiguityGapLimit` (holes from wiped/
    * pruned nodes are fine, cross-era bridges are not); exclude candidates
-   * whose OWN span exceeds `mergeMaxSourceSpanMessages` (replay-era wide-
-   * span summaries would bridge anything they join); merge the oldest run
-   * that still has `threshold` members.
+   * whose OWN span exceeds the level-scaled `mergeMaxSourceSpanMessages`
+   * limit (replay-era wide-span summaries would bridge anything they join);
+   * merge the oldest run that still has `threshold` members.
    */
+
+  /**
+   * Deduped LOUD log for merge-candidate exclusions. A silently-dropped
+   * candidate is a silently-stalled pyramid: the flat wide-span quarantine
+   * kept every mythos L4 out of the candidate pool for weeks with no
+   * externally visible signal — the merge queue simply read as empty while
+   * the fold floor sat ~23k tokens too high (found 2026-08-17, subagent
+   * store-clone expedition). One warn per summary id per process.
+   */
+  private _mergeExclusionWarned = new Set<string>();
+  protected warnMergeExclusion(id: string, detail: string): void {
+    if (this._mergeExclusionWarned.has(id)) return;
+    this._mergeExclusionWarned.add(id);
+    console.warn(`[autobiographical] merge-candidate excluded: ${detail}`);
+  }
+
   protected contiguousMergeCandidates(
     unmerged: SummaryEntry[],
     threshold: number,
@@ -5688,13 +5704,39 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       for (const m of ch.messages) messageOrder.set(m.id, seq++);
     }
     const gapLimit = this.config.mergeContiguityGapLimit ?? 300;
-    const spanLimit = this.config.mergeMaxSourceSpanMessages ?? 1500;
+    const spanBase = this.config.mergeMaxSourceSpanMessages ?? 1500;
+    const mergeK = this.config.mergeThreshold ?? 6;
     const withPos: Array<{ s: SummaryEntry; first: number; last: number }> = [];
     for (const s of unmerged) {
       const first = messageOrder.get(s.sourceRange.first);
       const last = messageOrder.get(s.sourceRange.last);
-      if (first === undefined || last === undefined) continue;
-      if (Math.abs(last - first) > spanLimit) continue; // wide-span quarantine
+      if (first === undefined || last === undefined) {
+        // Pruned/missing source messages: the candidate can NEVER merge.
+        // This was a silent drop (rev-5 review: "frontier debt, no log").
+        this.warnMergeExclusion(
+          s.id,
+          `L${s.level} ${s.id}: source position unresolved (pruned source messages?) — permanently unmergeable, frontier debt`,
+        );
+        continue;
+      }
+      // Wide-span quarantine, scaled by level. Legitimate spans grow ~k× per
+      // level, so a FLAT limit silently forbids all consolidation above the
+      // level where it matches a healthy node's span: mythos 2026-08 — every
+      // L4 spans 3.0k–6.9k messages > 1500, so an L5 was structurally
+      // impossible at any store state and the fold floor sat ~23k above
+      // where one L5 puts it. The damage signature this guard exists for
+      // (replay-era bridge summaries, 2026-07-12) is "wide FOR ITS LEVEL",
+      // not absolute width. Limits for L1–L3 are unchanged from the flat
+      // default; L4 gets base×k, L5 base×k², …
+      const spanLimit = spanBase * Math.pow(mergeK, Math.max(0, (s.level ?? 1) - 3));
+      const span = Math.abs(last - first);
+      if (span > spanLimit) {
+        this.warnMergeExclusion(
+          s.id,
+          `L${s.level} ${s.id}: wide-span quarantine — span ${span} msgs > limit ${spanLimit} (base ${spanBase} × ${mergeK}^${Math.max(0, (s.level ?? 1) - 3)})`,
+        );
+        continue;
+      }
       withPos.push({ s, first: Math.min(first, last), last: Math.max(first, last) });
     }
     withPos.sort((a, b) => a.first - b.first);

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -600,9 +600,17 @@ export interface AutobiographicalConfig {
   maxCompressionImageBytes?: number;
 
   /**
-   * Merge grouping: exclude candidates whose OWN source span exceeds this
-   * many messages (replay-era summaries can span the entire chronicle and
-   * would bridge any run they join). They stay on the frontier. Default 1500.
+   * Merge grouping: exclude candidates whose OWN source span exceeds the
+   * level-scaled limit `base × mergeThreshold^(max(0, level − 3))`, where
+   * this value is the base (replay-era summaries can span the entire
+   * chronicle and would bridge any run they join). Level-scaled because
+   * legitimate spans grow ~mergeThreshold× per level: a flat limit silently
+   * forbids all consolidation above the level whose healthy span exceeds it
+   * (mythos 2026-08: every L4 spanned 3.0k–6.9k msgs > 1500 → L5 merges
+   * structurally impossible, fold floor stuck ~23k high). L1–L3 limits equal
+   * the base, unchanged from the historical flat behavior. Excluded
+   * candidates stay on the frontier and are logged loudly (once per id).
+   * Default base 1500.
    */
   mergeMaxSourceSpanMessages?: number;
 

--- a/test/merge-span-scale.test.ts
+++ b/test/merge-span-scale.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Level-scaled wide-span quarantine (2026-08-17) — regression tests.
+ *
+ * The flat `mergeMaxSourceSpanMessages` default (1500) silently forbade all
+ * consolidation above the level whose healthy span exceeds it: on mythos,
+ * every L4 legitimately spans 3.0k–6.9k messages, so all eight were
+ * quarantined and an L5 was structurally impossible at any store state —
+ * with no log, the merge queue simply read as empty while the fold floor sat
+ * ~23k tokens above where one L5 puts it. The limit is now scaled
+ * `base × mergeThreshold^(max(0, level − 3))` (L1–L3 unchanged), and every
+ * exclusion — wide-span or unresolved-source — warns loudly, once per id.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { AutobiographicalStrategy } from '../src/strategies/autobiographical.js';
+import type { SummaryEntry } from '../src/types/strategy.js';
+
+class Probe extends AutobiographicalStrategy {
+  setChunks(messageIds: string[]): void {
+    (this as unknown as { chunks: unknown[] }).chunks = [
+      { messages: messageIds.map((id) => ({ id })) },
+    ];
+  }
+  pick(unmerged: SummaryEntry[], threshold: number): SummaryEntry[] | null {
+    return this.contiguousMergeCandidates(unmerged, threshold);
+  }
+}
+
+function summary(id: string, first: number, last: number, level = 2): SummaryEntry {
+  return {
+    id, level, content: `s ${id}`, tokens: 100, sourceLevel: level - 1,
+    sourceIds: [`x-${id}`],
+    sourceRange: { first: `m-${first}`, last: `m-${last}` },
+    created: 1,
+  } as SummaryEntry;
+}
+
+function probe(messages: number): Probe {
+  const p = new Probe({ adaptiveResolution: true, autoTickOnNewMessage: false });
+  p.setChunks(Array.from({ length: messages }, (_, i) => `m-${i}`));
+  return p;
+}
+
+function captureWarns(fn: () => void): string[] {
+  const warns: string[] = [];
+  const orig = console.warn;
+  console.warn = (...args: unknown[]) => { warns.push(args.map(String).join(' ')); };
+  try { fn(); } finally { console.warn = orig; }
+  return warns;
+}
+
+test('the mythos regression: six healthy L4s (span ~3k each) merge into an L5', () => {
+  const p = probe(20000);
+  // Contiguous L4 run with realistic spans (3032–3400 msgs each) — every one
+  // of these exceeded the old flat 1500 limit and was silently quarantined.
+  const unmerged = [
+    summary('l4-a', 0, 3100, 4), summary('l4-b', 3101, 6200, 4),
+    summary('l4-c', 6201, 9500, 4), summary('l4-d', 9501, 12600, 4),
+    summary('l4-e', 12601, 15900, 4), summary('l4-f', 15901, 19000, 4),
+  ];
+  const picked = p.pick(unmerged, 6);
+  assert.ok(picked, 'L4 run must be merge-eligible under the scaled limit');
+  assert.deepEqual(picked.map((s) => s.id), ['l4-a', 'l4-b', 'l4-c', 'l4-d', 'l4-e', 'l4-f']);
+});
+
+test('a wide-FOR-ITS-LEVEL candidate is still quarantined (protection preserved)', () => {
+  const p = probe(5000);
+  // An L2 spanning 4000 messages is the replay-era bridge signature the
+  // guard exists for; it must stay out even though an L4 of the same span
+  // would be healthy.
+  const unmerged = [
+    summary('bridge', 0, 4000, 2),
+    summary('a', 0, 200), summary('b', 201, 400), summary('c', 401, 600),
+    summary('d', 601, 800), summary('e', 801, 1000), summary('f', 1001, 1200),
+  ];
+  const warns = captureWarns(() => {
+    const picked = p.pick(unmerged, 6);
+    assert.ok(picked);
+    assert.ok(!picked.some((s) => s.id === 'bridge'), 'bridge must be excluded');
+  });
+  assert.ok(warns.some((w) => w.includes('wide-span quarantine') && w.includes('bridge')),
+    `expected loud quarantine warn, got: ${warns.join(' | ')}`);
+});
+
+test('scaled boundary: L4 span at exactly base×k passes; one over is excluded', () => {
+  const base = 1500, k = 6; // defaults → L4 limit 9000
+  const p = probe(20000);
+  const atLimit = [summary('ok', 0, base * k, 4)]; // span == 9000
+  const overLimit = [summary('wide', 0, base * k + 1, 4)]; // span == 9001
+  // threshold 1 so the single candidate reaches the exclusion loop
+  // (unmerged.length < threshold short-circuits before it).
+  const warnsOk = captureWarns(() => {
+    assert.ok(p.pick(atLimit, 1), 'span==limit must be pickable');
+  });
+  assert.ok(!warnsOk.some((w) => w.includes('wide-span')), 'span==limit must pass');
+  const warnsOver = captureWarns(() => {
+    assert.equal(p.pick(overLimit, 1), null);
+  });
+  assert.ok(warnsOver.some((w) => w.includes('wide-span') && w.includes('wide')),
+    'span>limit must warn');
+});
+
+test('unresolved source positions warn loudly instead of silently dropping', () => {
+  const p = probe(1000);
+  const unmerged = [summary('ghost', 5000, 5100)]; // m-5000 not in chunks
+  const warns = captureWarns(() => {
+    assert.equal(p.pick(unmerged, 1), null);
+  });
+  assert.ok(warns.some((w) => w.includes('source position unresolved') && w.includes('ghost')),
+    `expected frontier-debt warn, got: ${warns.join(' | ')}`);
+});
+
+test('exclusion warns are deduped per summary id', () => {
+  const p = probe(5000);
+  const unmerged = [summary('bridge', 0, 4000, 2)];
+  const warns = captureWarns(() => {
+    p.pick(unmerged, 1);
+    p.pick(unmerged, 1);
+    p.pick(unmerged, 1);
+  });
+  assert.equal(warns.filter((w) => w.includes('bridge')).length, 1,
+    'one warn per id per process');
+});


### PR DESCRIPTION
## What

`contiguousMergeCandidates`'s wide-span quarantine (`mergeMaxSourceSpanMessages`, default 1500) is a flat message-count limit on a quantity that grows ~`mergeThreshold`× per level. This PR scales it — `base × mergeThreshold^(max(0, level − 3))` — and makes every merge-candidate exclusion log loudly (deduped per id), including the previously-silent unresolved-source drop.

## Why

Rehearsal repair on a mythos store clone (2026-08-17) found the L4→L5 consolidation stall's root cause: **every legitimate L4 spans 3.0k–6.9k messages > 1500, so all eight were quarantined and an L5 was structurally impossible at any point in the store's history.** No corruption — the pyramid's natural growth ran into a guard calibrated two levels down. Consequences, measured with the real solver on the clone:

- fully-folded middle floor **121,733 → 98,866 (−22.9k)** once an L5 exists — the difference between a ~10–20k dead band (every compile budget-forced, ~1.4 full-window rotations/hour) and a ~44k one.
- The stall was invisible: quarantine drops candidates with a bare `continue`, so the merge queue simply reads as empty. Finding it took a store-clone expedition; a single warn line would have made it a grep.

**This is fleet-general**: every long-lived agent on the autobiographical strategy hits the same wall when its L4 spans cross 1500 messages.

## Design

- **L1–L3 behavior unchanged** (limits equal the base) — the tiers where the 2026-07-12 replay-era-bridge incident actually lived get no behavior change to re-validate.
- **The guard's real signal is preserved**: the damage signature is "wide *for its level*" (an L2 spanning 4000 = bridge fossil; an L4 spanning 4000 = healthy). Scaling keeps that discriminating power at every level instead of conflating it with absolute width; the other two defenses (positional ordering, `mergeContiguityGapLimit`) are untouched.
- **No more silent exclusions**: wide-span quarantine and unresolved-source (pruned messages — the rev-5 review's "frontier debt, no log" item) both `console.warn` with id/level/span/limit, once per summary id per process.
- Retires the knob-raising treadmill (no L6 wall at ~150k messages).

## Relation to the mythos runbook

The interim plan was a per-agent recipe override (`"mergeMaxSourceSpanMessages": 8000` on mythos). With this merged and deployed, that override becomes unnecessary — the default scales — and the runbook simplifies to deploy + restart + let the resident's own model produce the L5 through the normal drain (on-policy invariant preserved by construction).

## Tests

New `test/merge-span-scale.test.ts` (5): the mythos L4-run regression merges under scaled defaults; a wide-for-its-level L2 is still quarantined (with warn); exact boundary at base×k; unresolved-source warns instead of silently dropping; warns dedupe per id. Full suite: **474/474** (clean `dist/` rebuild — note for reviewers: stale compiled tests from other branches in `dist/` can produce phantom failures; `rm -rf dist && npm run build` first).

## Deploy notes

Fleet runs cm from local checkouts and loads `dist/` under fkm — deploy = pull + `npm run build` + restart. On restart, expect (this is the intended behavior): `[autobiographical] merge-candidate excluded` lines for any genuinely anomalous nodes, followed by L4→L5 merge production on stores whose L4 tier is ready — mythos will produce its first L5 (a Fable-5-authored consolidation of ~5.4M tokens of June–July history; the refusal→merge-quarantine→re-author path covers a classifier trip on the merge payload). Suggest watching the first drain on mythos before fleet-wide rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)