### PR TITLE
fix(autobio): preserve source order across message id widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ Releases up to and including 0.6.2 predate this file; for their contents see
 
 ## Unreleased
 
+### Fixed
+
+- Compression recall pairs now follow canonical message-store order rather
+  than lexical source-ID order, preserving chronology and stable prompt-cache
+  prefixes when decimal message IDs cross a width boundary (for example,
+  `"99"` to `"100"`).
+
 ## 0.6.3 — 2026-08-03
 
 ### Added

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -4761,13 +4761,26 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     // optimization that scales catastrophically: a 4000-message import
     // converged to ~500 L1s that never aged out, blowing the 200k
     // window around chunk 118.
+    // Message IDs are opaque strings, not sortable sequence numbers. Chronicle's
+    // default IDs happen to be decimal text, where lexical order corrupts the
+    // timeline at the first width transition (`"103" < "15"`). Use the store's
+    // canonical order instead so recall pairs remain chronological for every ID
+    // representation and newly-created summaries extend rather than splice the
+    // provider-cache prefix.
+    const messageOrder = new Map<MessageId, number>(
+      allMessages.map((message, index) => [message.id, index]),
+    );
     const priorSummaries = this.summaries
       // Skip empty-content summaries: emitting `{type:'text', text:''}` as a
       // recall pair triggers Anthropic 400 "text content blocks must be
       // non-empty", which stalls ALL compression (mirrors the render-path guard
       // + load-drop). A single empty summary otherwise poisons every compression.
       .filter((s) => !s.mergedInto && !!s.content && s.content.trim().length > 0)
-      .sort((a, b) => a.sourceRange.first.localeCompare(b.sourceRange.first));
+      .sort((a, b) => {
+        const aOrder = messageOrder.get(a.sourceRange.first) ?? Number.MAX_SAFE_INTEGER;
+        const bOrder = messageOrder.get(b.sourceRange.first) ?? Number.MAX_SAFE_INTEGER;
+        return aOrder - bOrder || a.sourceRange.first.localeCompare(b.sourceRange.first);
+      });
 
     // Leaf message coverage of every live summary — the rendering
     // authority for the one-to-one invariant: a message covered by a

--- a/test/head-window-order.test.ts
+++ b/test/head-window-order.test.ts
@@ -121,6 +121,53 @@ describe('Compression prompt ordering (confabulation regression)', () => {
     await manager.close();
   });
 
+  it('keeps prior recalls in Chronicle order when decimal message IDs cross 99', async () => {
+    cleanup();
+    const { membrane, calls } = createCapturingMembrane();
+    const strategy = new AutobiographicalStrategy({
+      compressionModel: TEST_COMPRESSION_MODEL,
+      targetChunkTokens: 80,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+      hierarchical: true,
+      mergeThreshold: 1000,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+      membrane: membrane as any,
+    });
+
+    const filler = (i: number) => `event ${i} ` + 'chronological substantive history '.repeat(8);
+    for (let i = 0; i < 150; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent', [t(filler(i))]);
+    }
+
+    await drain(manager);
+    let crossedThreeDigits = false;
+    for (const call of calls) {
+      const recallIds = call.messages.flatMap((message) =>
+        message.content.flatMap((block) => {
+          const match = /^\[CM\] Recall memory (.+)\.$/.exec((block as { text?: string }).text ?? '');
+          return match ? [match[1]] : [];
+        }),
+      );
+      const sourceStarts = recallIds.map((id) => {
+        const summary = manager.getSummary(id);
+        assert.ok(summary, `recalled summary ${id} must exist`);
+        return Number(summary.sourceRange.first);
+      });
+      if (sourceStarts.some((id) => id >= 100)) crossedThreeDigits = true;
+      assert.deepStrictEqual(
+        sourceStarts,
+        [...sourceStarts].sort((a, b) => a - b),
+        `recall pairs must follow Chronicle order, got ${sourceStarts.join(', ')}`,
+      );
+    }
+    assert.ok(crossedThreeDigits, 'fixture must exercise the decimal-ID width transition');
+    await manager.close();
+  });
+
   it('thin chunks are stubbed mechanically — no LLM call, non-empty content', async () => {
     cleanup();
     const { membrane, calls } = createCapturingMembrane();


### PR DESCRIPTION
## Problem

Compression prompts sort prior summaries with `sourceRange.first.localeCompare(...)`. Message IDs are opaque strings, and Chronicle's default decimal-text IDs therefore become non-chronological at width transitions (for example, `"103"` sorts before `"15"`).

That presents recall pairs to the summarizer out of source order and splices newer memories into the middle of an otherwise stable provider-cache prefix.

## Changes

- Build an ID-to-position map from `MessageStore.getAll()` and order prior summaries by canonical store position.
- Keep a deterministic lexical fallback only for summaries whose first source message is missing from the store.
- Add a regression fixture with 150 messages that proves it crosses into three-digit IDs and checks every compression call's recall chronology.
- Add the behavior fix under `CHANGELOG.md`'s existing `## Unreleased` section.

No companion PRs; this change is safe to land independently.

## Tests

- Current `main`: `npm run build && npm test` — 479 pass / 0 fail.
- This branch: `bun run build` followed by the repository test command — 480 pass / 0 fail.
- `npm run typecheck` — pass.
- Regression validity: copying only the new test onto unfixed `main` fails 1/4 tests with a non-chronological recall sequence (`1, 11, 6` instead of `1, 6, 11`).
- Real-store check: 24 strictly sequential compression calls completed on a Chronicle with 9 pre-existing L1 summaries and roughly 510 pending chunks. Every prompt recalled `L1-0, L1-1, ...` chronologically; cache reads grew from 24,769 to 73,065 tokens while per-call cache writes remained incremental (50,331 total versus 1,084,458 in the rejected unfixed run, a 95.4% reduction). The resulting store reopened cleanly with 33 L1 summaries. No store content is included in this PR.

## Not verified

- The bounded real-store run did not drain the remaining 486-chunk backlog or execute the five queued higher-level merges.
- No alternate `MessageId` implementation beyond Chronicle's default IDs was exercised against a real store; the implementation treats IDs as opaque and relies only on `MessageStore.getAll()` ordering.

---

- [x] `CHANGELOG.md` updated under `## Unreleased`.

🤖 Generated with [OpenAI Codex](https://openai.com/codex)
