### PR TITLE
fix(cache): preserve append endpoint beyond provider lookback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Releases up to and including 0.6.2 predate this file; for their contents see
 
 ### Fixed
 
+- Append-only autobiographical compiles now preserve the previous request's
+  endpoint as an explicit cache breakpoint, avoiding recent-tail cache misses
+  when a tool-heavy turn appends more than the provider's 20-block lookback.
 - Compression recall pairs now follow canonical message-store order rather
   than lexical source-ID order, preserving chronology and stable prompt-cache
   prefixes when decimal message IDs cross a width boundary (for example,

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -7397,8 +7397,10 @@ export class AutobiographicalStrategy implements ResettableStrategy {
    * divergence-aligned ≈ −10%). So: diff this compile's entries against the
    * previous compile's (by content identity — bytes are what the provider
    * hashes) and mark the last entry of the SURVIVING prefix instead. In
-   * steady state (append-only) the boundary degrades gracefully to the seam;
-   * after a rotation it drops to the deepest byte-stable point, so subsequent
+   * steady state (append-only) this preserves the previous request endpoint
+   * explicitly; relying on the new end marker's backward search would miss
+   * that cache entry after more than 20 appended provider blocks. After a
+   * rotation the marker drops to the deepest byte-stable point, so subsequent
    * requests re-read everything above the churn instead of re-writing it.
    * See docs/unified-solve-design.md §9.2b.
    *
@@ -7432,8 +7434,10 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const historyEnd = firstTail - 1; // last middle (folded-history) entry
 
     // Measured stable prefix: first index where this compile's entry bytes
-    // diverge from the previous compile's. No previous compile → whole window
-    // counts as stable (seam placement, the old behavior).
+    // diverge from the previous compile's. No previous compile → seam
+    // placement, the old bounded cold-start behavior. Later pure appends mark
+    // the previous endpoint itself so reuse never depends on Anthropic finding
+    // it within the new end marker's 20-block backward-search window.
     const keys = entries.map(
       (e) => `${e.participant} ${JSON.stringify(e.content)}`,
     );
@@ -7445,7 +7449,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       firstDiff = i;
     }
     this._prevCacheKeys = keys;
-    const stableEnd = Math.min(historyEnd, firstDiff - 1);
+    const stableEnd = prev ? firstDiff - 1 : historyEnd;
 
     const marks = new Set<number>();
     if (lastHead >= 0) marks.add(lastHead);            // system / head block

--- a/test/cache-marker-stable-prefix.test.ts
+++ b/test/cache-marker-stable-prefix.test.ts
@@ -3,7 +3,8 @@
  *
  * Load-bearing properties:
  *  - first compile (no previous) degrades to seam placement: {head, historyEnd, end};
- *  - append-only compile keeps the seam marker (stable prefix = whole previous window);
+ *  - append-only compile marks the previous endpoint explicitly, so pure-append
+ *    reuse does not depend on Anthropic's bounded 20-block backward search;
  *  - a fold rotation that rewrites the middle drops the marker to the last
  *    byte-surviving entry, NOT the seam — the seam assumption is the measured
  *    failure (mythos llm-calls 2026-08-13..17: ~1.4 deep rewrites/hour);
@@ -53,7 +54,7 @@ test('first compile: seam placement {head, historyEnd, end}', () => {
   assert.deepEqual(marksOf(es), [1, 7, 10]); // lastHead=1, historyEnd=7, end=10
 });
 
-test('append-only compile keeps the seam marker', () => {
+test('append-only compile preserves the previous endpoint', () => {
   const s = new Exposed({});
   const a = fixture();
   s.place(a.es, a.head, a.tail);
@@ -61,7 +62,28 @@ test('append-only compile keeps the seam marker', () => {
   b.es.push(entry('t3', 'raw-3'));
   b.tail.add('t3');
   s.place(b.es, b.head, b.tail);
-  assert.deepEqual(marksOf(b.es), [1, 7, 11]);
+  assert.deepEqual(marksOf(b.es), [1, 10, 11]);
+});
+
+test('append-only endpoint remains explicit beyond the provider lookback window', () => {
+  const s = new Exposed({});
+  const a = fixture();
+  s.place(a.es, a.head, a.tail);
+  const previousEnd = a.es.length - 1;
+
+  const b = fixture();
+  // Anthropic searches at most 20 blocks backward from a breakpoint. A
+  // tool-heavy turn can append more than that between compiles, so the prior
+  // endpoint must remain a breakpoint in the next request rather than merely
+  // being byte-identical somewhere in the unmarked tail.
+  for (let i = 3; i < 24; i++) {
+    b.es.push(entry(`t${i}`, `raw-${i}`));
+    b.tail.add(`t${i}`);
+  }
+  s.place(b.es, b.head, b.tail);
+
+  assert.ok(b.es.length - 1 - previousEnd > 20);
+  assert.deepEqual(marksOf(b.es), [1, previousEnd, b.es.length - 1]);
 });
 
 test('rotation drops the marker to the surviving prefix, not the seam', () => {


### PR DESCRIPTION
## Problem

Anthropic searches backward only 20 content blocks from a cache breakpoint.
Autobiographical compiles marked the previous request's endpoint when it was
current, but the next append-only compile replaced that explicit marker with
the folded-history seam. If a tool-heavy turn appended more than 20 provider
blocks, the new endpoint could no longer discover the previous endpoint's cache
write. The recent conversational tail could then be processed and written
again even though its bytes were unchanged.

## Changes

- On the first compile, retain the existing bounded cold-start markers at the
  head, folded-history seam, and current endpoint.
- On later compiles, mark the last byte-identical entry from the previous
  compile. For a pure append this is the previous request endpoint; after a
  rewrite it remains the deepest surviving prefix.
- Keep the three-marker maximum unchanged.
- Add an explicit regression with 21 appended tail entries, plus update the
  existing append-only expectation and changelog.

This complements merged context-manager PR #63 and uses the previous-compile
cache keys introduced there. It is independent of the agent-framework PRs.

## Tests

- `npm run build` — passed.
- Focused cache-marker suite — 6 passed, 0 failed.
- `npm test` — 481 passed, 0 failed.
- `npx tsc --noEmit` — passed.
- Regression discriminator against the unfixed marker logic — 4 passed, 2
  failed: one append produced markers `[1, 7, 11]` instead of `[1, 10, 11]`,
  and 21 appends produced `[1, 7, 31]` instead of `[1, 10, 31]`.

## Not verified

- A live Anthropic request showing `cache_read_input_tokens` across a tool-heavy
  turn.
- Billing impact against a real production message store.

---

- [x] `CHANGELOG.md` updated under `## Unreleased`.

🤖 Generated with OpenAI Codex
