### PR TITLE
fix: repair compression accounting and add explicit zero-recall surgery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ Releases up to and including 0.6.2 predate this file; for their contents see
 
 ### Fixed
 
+- Compression-refusal fallback admission now uses provider-aware total input
+  usage after the canonical call (including disjoint Anthropic/Bedrock cache
+  counters without double-counting subset-style providers), fails closed on
+  zero/partial/unknown usage, and versions the durable accounting contract so
+  legacy byte-bound quarantines remain evidence without consuming the repaired
+  per-chunk shape allowance.
 - Append-only autobiographical compiles now preserve the previous request's
   endpoint as an explicit cache breakpoint, avoiding recent-tail cache misses
   when a tool-heavy turn appends more than the provider's 20-block lookback.

--- a/docs/compression-recall-curve-fallback-spec.md
+++ b/docs/compression-recall-curve-fallback-spec.md
@@ -99,14 +99,23 @@ Default maximum: 3 fallback variants. Make configurable, e.g.:
 Fallback admission uses `compressionContextBudgetTokens` (default `200000`),
 the combined model context budget for request input plus the configured
 `maxTokens` output reserve. The canonical request is still issued unchanged.
-Admission is deterministic before inference: it uses a UTF-8-byte upper bound
-over every input-bearing field of the complete normalized variant (head,
-recall, raw middle, chunk, tools, instruction, system/provider fields), a
-per-message formatter-envelope allowance, and the output reserve. After the
-canonical refusal reports provider input usage, each variant is admitted as
-`max(complete deterministic variant bound, canonical provider input usage +
-positive expansion delta) + output reserve`. Stored `SummaryEntry.tokens` are
-never admission authority.
+Admission is deterministic before inference. Before authoritative canonical
+usage exists, it uses a conservative UTF-8-byte bound over every input-bearing
+field of the complete normalized variant (head, recall, raw middle, chunk,
+tools, instruction, system/provider fields), a per-message formatter-envelope
+allowance, and the output reserve. After canonical refusal reports complete
+provider input usage, v2 admission uses `provider total input + positive
+serialized expansion delta + output reserve`; the complete-request bound
+remains the fail-closed path when usage is absent, zero/partial, or from an
+unknown accounting contract. Provider adapters whose cache counters are
+disjoint (Anthropic/Bedrock) include cache-write/read totals; adapters whose
+cache-read count is a subset use their positive total `inputTokens` once.
+Physical request-byte enforcement remains a separate provider/transport
+constraint. A positive complete provider total is authoritative even when it is
+smaller than the deterministic byte bound: canonical refusal proves that exact
+unchanged request was accepted and counted, and a fallback provider error stays
+inside the bounded attempt curve. Stored `SummaryEntry.tokens` are never
+admission authority.
 The ordered plan records every rejection and at most the normalized positive
 fallback limit of provider attempts. An over-budget variant is recorded and
 skipped without preventing a later eligible variant.

--- a/scripts/one-shot-zero-recall-surgery.ts
+++ b/scripts/one-shot-zero-recall-surgery.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/** Explicit, reusable, default-off zero-recall compression surgery.
+ *
+ * Usage: bun dist/scripts/one-shot-zero-recall-surgery.js --config op.json --execute
+ * Without --execute it validates hashes/config and makes no branch or provider call.
+ */
+import { createHash } from 'node:crypto';
+import { createReadStream, readFileSync, writeFileSync } from 'node:fs';
+import { ContextManager } from '../src/context-manager.js';
+import { AutobiographicalStrategy } from '../src/strategies/autobiographical.js';
+import { transformZeroRecallCompression } from '../src/surgery/zero-recall-compression.js';
+import { Membrane, AnthropicAdapter, NativeFormatter, type NormalizedRequest } from '@animalabs/membrane';
+
+interface Config {
+  storePath: string;
+  namespace: string;
+  branchName: string;
+  expectedParentBranch: string;
+  expectedRecordsSha256: string;
+  toolsPath: string;
+  expectedToolsSha256: string;
+  targetChunkIndex: number;
+  expectedSourceRange: [string, string];
+  expectedQuarantineKey: string;
+  summaryParticipant: string;
+  strategyConfig: Record<string, unknown>;
+  receiptPath: string;
+  acknowledgeStoppedCopiedOrBackedUpStore: true;
+}
+const args = process.argv.slice(2); const ci = args.indexOf('--config');
+if (ci < 0 || !args[ci + 1]) throw new Error('Usage: --config op.json [--execute]');
+const execute = args.includes('--execute');
+const config = JSON.parse(readFileSync(args[ci + 1], 'utf8')) as Config;
+if (config.acknowledgeStoppedCopiedOrBackedUpStore !== true) throw new Error('Explicit stopped/copy acknowledgement required');
+if (!/^(treatment|surgery)\//.test(config.branchName)) throw new Error('branchName must begin treatment/ or surgery/');
+if (!Number.isInteger(config.targetChunkIndex)) throw new Error('targetChunkIndex must be an integer');
+
+async function hashFile(path: string): Promise<string> { const h=createHash('sha256'); for await (const c of createReadStream(path)) h.update(c); return h.digest('hex'); }
+const recordsSha256=await hashFile(`${config.storePath}/records.log`); if(recordsSha256!==config.expectedRecordsSha256)throw new Error(`records hash mismatch ${recordsSha256}`);
+const toolBytes=readFileSync(config.toolsPath); const toolsSha256=createHash('sha256').update(toolBytes).digest('hex'); if(toolsSha256!==config.expectedToolsSha256)throw new Error(`tools hash mismatch ${toolsSha256}`);
+const tools=JSON.parse(toolBytes.toString('utf8'));
+const preview={createdAt:new Date().toISOString(),execute,config:{...config,strategyConfig:'[recorded in config file]'},recordsSha256,toolsSha256,toolCount:tools.length};
+if(!execute){console.log(JSON.stringify(preview,null,2));process.exit(0);}
+if(!process.env.ANTHROPIC_API_KEY)throw new Error('ANTHROPIC_API_KEY required only with --execute');
+const actual=new Membrane(new AnthropicAdapter({apiKey:process.env.ANTHROPIC_API_KEY}),{formatter:new NativeFormatter()});
+let call: Record<string,unknown>|null=null;
+const proxy=new Proxy(actual,{get(target,prop,receiver){if(prop!=='complete'){const v=Reflect.get(target,prop,receiver);return typeof v==='function'?v.bind(target):v;}return async(req:NormalizedRequest)=>{if(call)throw new Error('ONE_CALL_CAP');const tr=transformZeroRecallCompression(req.messages);const sent={...req,messages:tr.messages};const raw=JSON.stringify(sent);const startedAt=new Date().toISOString();call={startedAt,removedRecallIds:tr.removedRecallIds,originalMessages:tr.originalMessageCount,sentMessages:tr.sentMessageCount,originalRequestSha256:tr.originalSha256,transformedRequestSha256:tr.transformedSha256,transformedBytes:Buffer.byteLength(raw),status:'started'};try{const response=await target.complete(sent);const usage=response.details?.usage??response.usage;call={...call,endedAt:new Date().toISOString(),status:'completed',stopReason:response.stopReason,usage,contentTypes:response.content.map(b=>b.type)};return response;}catch(e){call={...call,endedAt:new Date().toISOString(),status:'error',providerError:{name:(e as Error).name,message:(e as Error).message}};throw e;}};}});
+const strategy=new AutobiographicalStrategy({...config.strategyConfig,summaryParticipant:config.summaryParticipant,autoTickOnNewMessage:false} as never);
+const manager=await ContextManager.open({path:config.storePath,strategy,membrane:proxy,namespace:config.namespace});
+manager.setToolDefinitions(tools);
+const parent=manager.currentBranch(); if(parent.name!==config.expectedParentBranch)throw new Error(`parent branch mismatch ${parent.name}`);
+const chunks=(strategy as unknown as {chunks:Array<{index:number,messages:Array<{id:string}>}>}).chunks;const chunk=chunks.find(c=>c.index===config.targetChunkIndex);if(!chunk)throw new Error(`chunk ${config.targetChunkIndex} absent`);const range:[string,string]=[String(chunk.messages[0]?.id),String(chunk.messages.at(-1)?.id)];if(JSON.stringify(range)!==JSON.stringify(config.expectedSourceRange))throw new Error(`source range mismatch ${range}`);const parentQuarantine=strategy.getCompressionQuarantineStatus();if(!parentQuarantine.keys.includes(config.expectedQuarantineKey))throw new Error(`expected quarantine key absent on parent ${config.expectedQuarantineKey}`);
+const branch=await manager.fork(config.branchName);const activeStrategy=manager.getStrategy() as AutobiographicalStrategy;const qBefore=activeStrategy.getCompressionQuarantineStatus();if(!qBefore.keys.includes(config.expectedQuarantineKey))throw new Error(`expected quarantine key absent after fork ${config.expectedQuarantineKey}`);await activeStrategy.clearCompressionRefusalQuarantine(config.expectedQuarantineKey);(activeStrategy as unknown as {compressionQueue:number[]}).compressionQueue=[config.targetChunkIndex];const beforeSummaryIds=new Set((activeStrategy as unknown as {summaries:Array<{id:string}>}).summaries.map(s=>s.id));let error:null|{name?:string;message?:string}=null;try{await manager.tick();}catch(e){error={name:(e as Error).name,message:(e as Error).message};}
+const newSummaries=(activeStrategy as unknown as {summaries:Array<{id:string,sourceRange?:unknown,content?:unknown}>}).summaries.filter(s=>!beforeSummaryIds.has(s.id)).map(s=>({id:s.id,sourceRange:s.sourceRange}));const after={branch:manager.currentBranch(),queue:[...(activeStrategy as unknown as {compressionQueue:number[]}).compressionQueue],quarantine:activeStrategy.getCompressionQuarantineStatus(),newSummaries};manager.close();
+const receipt={...preview,parentBranch:parent,branch,targetChunkIndex:config.targetChunkIndex,sourceRange:range,provenanceMode:'external-receipt-only',clearedQuarantineKey:config.expectedQuarantineKey,call,error,after};writeFileSync(config.receiptPath,JSON.stringify(receipt,null,2));console.log(JSON.stringify(receipt,null,2));console.log('RECEIPT_SHA256',await hashFile(config.receiptPath));if(error||newSummaries.length!==1||!call)process.exitCode=1;

--- a/scripts/one-shot-zero-recall.example.json
+++ b/scripts/one-shot-zero-recall.example.json
@@ -1,0 +1,16 @@
+{
+  "storePath": "/absolute/path/to/stopped-copy",
+  "namespace": "agents/resident",
+  "branchName": "surgery/resident/chunk-N-ISO",
+  "expectedParentBranch": "main",
+  "expectedRecordsSha256": "sha256",
+  "toolsPath": "/absolute/path/tools.json",
+  "expectedToolsSha256": "sha256",
+  "targetChunkIndex": 0,
+  "expectedSourceRange": ["first-message-id", "last-message-id"],
+  "expectedQuarantineKey": "exact-active-key",
+  "summaryParticipant": "resident",
+  "strategyConfig": {},
+  "receiptPath": "/absolute/path/receipt.json",
+  "acknowledgeStoppedCopiedOrBackedUpStore": true
+}

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -428,6 +428,7 @@ interface CompressionRefusalQuarantineRecord {
 }
 
 interface CompressionRefusalNormalizedConfig {
+  accountingVersion: number;
   fallbackLimit: number;
   contextBudgetTokens: number;
   requestConfig: NormalizedRequest['config'];
@@ -645,8 +646,9 @@ function sha256Json(value: unknown): string {
  */
 const compressionStateLocks = new WeakMap<JsStore, Map<string, Promise<void>>>();
 const compressionInFlight = new WeakMap<JsStore, Map<string, Promise<CompressionInFlightResult>>>();
+const COMPRESSION_BUDGET_ACCOUNTING_VERSION = 2;
 const COMPRESSION_BUDGET_ACCOUNTING_SOURCE =
-  'max(canonical_provider_input+positive_expansion,complete_normalized_request_utf8_bound)+output_reserve';
+  'provider_total_input+positive_serialized_delta_or_complete_normalized_request_utf8_bound+output_reserve:v2';
 const COMPRESSION_QUARANTINE_CHECKPOINT_EVENTS = 256;
 const COMPRESSION_QUARANTINE_MAX_ACTIVE = 1_024;
 
@@ -2236,12 +2238,33 @@ export class AutobiographicalStrategy implements ResettableStrategy {
 
   private compressionResponseInputTokens(response: unknown): number | undefined {
     if (!response || typeof response !== 'object') return undefined;
-    const usage = (response as { usage?: unknown }).usage;
+    const typed = response as {
+      usage?: unknown;
+      details?: { usage?: unknown; model?: { provider?: unknown } };
+    };
+    const detailed = typed.details?.usage;
+    const usage = detailed && typeof detailed === 'object' ? detailed : typed.usage;
     if (!usage || typeof usage !== 'object') return undefined;
-    const inputTokens = (usage as { inputTokens?: unknown }).inputTokens;
-    return typeof inputTokens === 'number' && Number.isFinite(inputTokens) && inputTokens >= 0
-      ? inputTokens
+    const read = (key: 'inputTokens' | 'cacheCreationTokens' | 'cacheReadTokens'): number | undefined => {
+      const value = (usage as Record<string, unknown>)[key];
+      return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+    };
+    const input = read('inputTokens');
+    const provider = typeof typed.details?.model?.provider === 'string'
+      ? typed.details.model.provider.toLowerCase()
       : undefined;
+    // Anthropic and Bedrock report uncached, cache-write, and cache-read input
+    // as disjoint counters. OpenAI/Gemini/OpenRouter report cache reads as a
+    // subset of inputTokens, so summing there would double-count.
+    if (provider === 'anthropic' || provider === 'bedrock') {
+      if (input === undefined) return undefined;
+      const total = input + (read('cacheCreationTokens') ?? 0) + (read('cacheReadTokens') ?? 0);
+      return total > 0 ? total : undefined;
+    }
+    // Unknown/other providers are authoritative only when they report a
+    // positive total input count. Zero/partial usage falls back to the
+    // complete normalized request bound rather than admitting blindly.
+    return input !== undefined && input > 0 ? input : undefined;
   }
 
   private fallbackContentBlockError(block: unknown, seen = new Set<object>()): string | undefined {
@@ -2569,9 +2592,10 @@ export class AutobiographicalStrategy implements ResettableStrategy {
   /**
    * Freeze the exact fallback/admission plan. Before canonical inference this
    * supplies a deterministic family identity; after a refusal it is rebuilt
-   * with authoritative canonical provider usage. Every admission still has a
-   * complete normalized-request floor, so tools/head/raw/config/provider fields
-   * cannot disappear when usage is absent or unexpectedly small.
+   * with authoritative canonical provider usage. When complete provider usage
+   * is absent or not authoritative, admission retains the conservative complete
+   * normalized-request bound; otherwise the unchanged canonical request is
+   * already represented by provider usage and only positive expansion is added.
    */
   private compressionRefusalPlan(
     canonicalRequest: NormalizedRequest,
@@ -2598,12 +2622,17 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       const providerExpandedInputTokens = canonicalProviderInputTokens === undefined
         ? undefined
         : canonicalProviderInputTokens + expansionDeltaTokens;
-      const boundedInputTokens = Math.max(
-        variant.deterministicInputBoundTokens,
-        providerExpandedInputTokens ?? 0,
-      );
-      const accountingSource = providerExpandedInputTokens !== undefined &&
-          providerExpandedInputTokens >= variant.deterministicInputBoundTokens
+      // Once the provider has counted the canonical request, that observed
+      // token total is the authoritative baseline. The complete normalized
+      // UTF-8 bound remains the fail-closed fallback when usage is absent, but
+      // must not override real token accounting: large invariant tool schemas
+      // can be megabytes of JSON while occupying a much smaller token window.
+      // The positive byte-delta below is deliberately conservative for the
+      // changed recall pair; unchanged head/tools/raw/config were physically
+      // accepted and counted by the canonical provider call.
+      const boundedInputTokens = providerExpandedInputTokens
+        ?? variant.deterministicInputBoundTokens;
+      const accountingSource = providerExpandedInputTokens !== undefined
         ? 'canonical_provider_usage_plus_expansion' as const
         : 'complete_normalized_request_bound' as const;
       const outputReserveTokens = Math.max(0, Math.ceil(variant.request.config.maxTokens));
@@ -3117,6 +3146,7 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     const contextBudgetTokens = this.normalizedCompressionContextBudget();
     const canonicalRequestBoundTokens = this.compressionRequestInputBoundTokens(canonicalRequest);
     const normalizedConfig: CompressionRefusalNormalizedConfig = {
+      accountingVersion: COMPRESSION_BUDGET_ACCOUNTING_VERSION,
       fallbackLimit,
       contextBudgetTokens,
       requestConfig: canonicalRequest.config,
@@ -5066,7 +5096,8 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     // success-clear, paid-off sweep, or operator clear (all of which
     // already match by chunkSourceHash).
     const sameHash = [...durableQuarantine.values()].filter(
-      (active) => active.record.chunkSourceHash === quarantineRecord.chunkSourceHash,
+      (active) => active.record.chunkSourceHash === quarantineRecord.chunkSourceHash &&
+        active.record.normalizedConfig?.accountingVersion === COMPRESSION_BUDGET_ACCOUNTING_VERSION,
     );
     const durableActive = durableQuarantine.get(quarantineRecord.key)
       ?? sameHash.find((active) => active.record.familyKey === quarantineRecord.familyKey)

--- a/src/surgery/zero-recall-compression.ts
+++ b/src/surgery/zero-recall-compression.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'node:crypto';
+import type { NormalizedMessage } from '@animalabs/membrane';
+
+export interface ZeroRecallTransformResult {
+  messages: NormalizedMessage[];
+  removedRecallIds: string[];
+  originalMessageCount: number;
+  sentMessageCount: number;
+  originalSha256: string;
+  transformedSha256: string;
+}
+
+function textOf(message: NormalizedMessage): string {
+  return message.content
+    .filter((block): block is Extract<(typeof message.content)[number], { type: 'text' }> => block.type === 'text')
+    .map((block) => block.text)
+    .join('\n');
+}
+
+/**
+ * Explicit surgical transform for ONE compression request.
+ *
+ * Removes complete `[CM] Recall memory …` marker/answer pairs only.
+ * It does not annotate the request, generated summary, or prior turns; all
+ * operation provenance belongs in the caller's external receipt.
+ * It never edits Chronicle or any source message. Callers must bind its use to
+ * an exact stopped store, branch, chunk, request hash and one-shot receipt.
+ */
+export function transformZeroRecallCompression(messages: readonly NormalizedMessage[]): ZeroRecallTransformResult {
+  const kept: NormalizedMessage[] = [];
+  const removedRecallIds: string[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const marker = message.participant === 'Context Manager'
+      ? textOf(message).match(/^\[CM\] Recall memory ([^.]+)\./)
+      : null;
+    if (!marker) {
+      kept.push(message);
+      continue;
+    }
+
+    const answer = messages[i + 1];
+    if (!answer || answer.participant === 'Context Manager') {
+      throw new Error(`Malformed recall pair for ${marker[1]}: missing assistant answer`);
+    }
+    removedRecallIds.push(marker[1]);
+    i++;
+  }
+
+  if (removedRecallIds.length === 0) {
+    throw new Error('No recall pairs found; refusing zero-recall surgery');
+  }
+
+
+  const originalJson = JSON.stringify(messages);
+  const transformedJson = JSON.stringify(kept);
+  return {
+    messages: kept,
+    removedRecallIds,
+    originalMessageCount: messages.length,
+    sentMessageCount: kept.length,
+    originalSha256: createHash('sha256').update(originalJson).digest('hex'),
+    transformedSha256: createHash('sha256').update(transformedJson).digest('hex'),
+  };
+}

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -691,11 +691,12 @@ export interface AutobiographicalConfig {
    * Total model context budget used to admit refusal-curve compression
    * requests, including the request input and the configured output reserve.
    * The canonical request remains unchanged and is always attempted first;
-   * only fallback variants are gated. Admission uses the greater of canonical
-   * provider input usage plus a positive expansion delta and a deterministic,
-   * byte-conservative bound over the complete normalized variant input
-   * (including config, tools, provider fields, and formatter envelopes), then
-   * adds the output reserve. Default: 200000.
+   * only fallback variants are gated. Before authoritative canonical usage
+   * exists, admission uses a conservative complete normalized-request bound.
+   * After canonical refusal reports complete provider input usage, admission
+   * uses provider-total input plus a positive serialized expansion delta, then
+   * adds the output reserve. Zero, partial, or unknown usage contracts retain
+   * the conservative bound. Default: 200000.
    */
   compressionContextBudgetTokens?: number;
 

--- a/test/compression-recall-curve.test.ts
+++ b/test/compression-recall-curve.test.ts
@@ -66,6 +66,10 @@ type AttemptHandler =
       stop: 'refusal' | 'end_turn' | 'max_tokens';
       text?: string;
       inputTokens?: number;
+      topLevelInputTokens?: number;
+      cacheCreationTokens?: number;
+      cacheReadTokens?: number;
+      provider?: string;
       omitUsage?: boolean;
     }
   | { raw: unknown }
@@ -83,7 +87,26 @@ function flexibleMembrane(handlers: AttemptHandler[]) {
         if ('raw' in handler) return handler.raw;
         const result = response(handler.stop, handler.text ?? '');
         if (handler.inputTokens !== undefined) result.usage.inputTokens = handler.inputTokens;
-        if (handler.omitUsage) delete (result as { usage?: unknown }).usage;
+        if (handler.topLevelInputTokens !== undefined) result.usage.inputTokens = handler.topLevelInputTokens;
+        if (handler.cacheCreationTokens !== undefined || handler.cacheReadTokens !== undefined || handler.provider) {
+          (result as unknown as { details: { usage: Record<string, number>; model: { provider: string } } }).details = {
+            usage: {
+              inputTokens: handler.inputTokens ?? result.usage.inputTokens,
+              outputTokens: result.usage.outputTokens,
+              ...(handler.cacheCreationTokens !== undefined
+                ? { cacheCreationTokens: handler.cacheCreationTokens }
+                : {}),
+              ...(handler.cacheReadTokens !== undefined
+                ? { cacheReadTokens: handler.cacheReadTokens }
+                : {}),
+            },
+            model: { provider: handler.provider ?? 'anthropic' },
+          };
+        }
+        if (handler.omitUsage) {
+          delete (result as { usage?: unknown }).usage;
+          delete (result as { details?: unknown }).details;
+        }
         return result;
       },
     } as never,
@@ -815,12 +838,141 @@ describe('compression refusal recall curves', () => {
     const record = quarantineEvents(fx.manager).find((event) => event.kind === 'exhausted')!
       .record as Record<string, unknown>;
     assert.equal(record.canonicalProviderInputTokens, 90_000);
-    assert.match(String(record.accountingSource), /canonical_provider_input/);
+    assert.match(String(record.accountingSource), /provider_total_input/);
     const plan = record.plan as Array<Record<string, unknown>>;
     assert.ok(plan.length > 0);
     assert.ok(plan.every((item) => item.disposition === 'admission_rejected'));
     assert.ok(plan.every((item) => item.accountingSource === 'canonical_provider_usage_plus_expansion'));
     assert.ok(plan.every((item) => Number(item.boundedInputTokens) > 90_000));
+    fx.manager.close();
+  });
+
+  it('provider usage replaces the invariant UTF-8 floor after canonical refusal', async () => {
+    const mock = flexibleMembrane([
+      { stop: 'refusal', inputTokens: 120_000, cacheCreationTokens: 40_000, cacheReadTokens: 20_000, provider: 'anthropic' },
+      { stop: 'end_turn', text: 'provider-counted fallback succeeded', inputTokens: 190_000 },
+    ]);
+    const fx = await fixture(mock.membrane, {
+      compressionContextBudgetTokens: 350_000,
+      compressionRefusalCurveFallbacks: 1,
+      headWindowTokens: 100_000,
+    });
+    fx.manager.setToolDefinitions([{
+      name: 'huge_invariant_tool_catalog',
+      description: 'schema inventory '.repeat(30_000),
+      inputSchema: {
+        type: 'object',
+        properties: { payload: { type: 'string', description: 'large field '.repeat(30_000) } },
+      },
+    }]);
+
+    await fx.strategy.run(fx.target, managerContext(fx.manager));
+    assert.equal(mock.calls.length, 2, 'observed canonical usage admits one fallback');
+    assert.equal(fx.target.compressed, true);
+    const requests = mock.calls.map((call) => Buffer.byteLength(JSON.stringify(call.request), 'utf8'));
+    assert.ok(requests[0]! > 350_000, 'invariant serialized request exceeds the token budget numerically');
+    const exhausted = quarantineEvents(fx.manager).find((event) => event.kind === 'exhausted');
+    assert.equal(exhausted, undefined, 'successful fallback leaves no quarantine');
+    fx.manager.close();
+  });
+
+  it('canonical provider accounting includes cache-write and cache-read tokens', async () => {
+    const mock = flexibleMembrane([
+      { stop: 'refusal', inputTokens: 2, cacheCreationTokens: 210_000, cacheReadTokens: 130_000, provider: 'anthropic' },
+      { stop: 'end_turn', text: 'must never be called' },
+    ]);
+    const fx = await fixture(mock.membrane, {
+      compressionContextBudgetTokens: 350_000,
+      compressionRefusalCurveFallbacks: 3,
+    });
+
+    await fx.strategy.run(fx.target, managerContext(fx.manager));
+    assert.equal(mock.calls.length, 1, 'full cached canonical usage plus output reserve blocks fallbacks');
+    const record = quarantineEvents(fx.manager).find((event) => event.kind === 'exhausted')!
+      .record as Record<string, unknown>;
+    assert.equal(record.canonicalProviderInputTokens, 340_002);
+    const plan = record.plan as Array<Record<string, unknown>>;
+    assert.ok(plan.length > 0);
+    assert.ok(plan.every((item) => item.accountingSource === 'canonical_provider_usage_plus_expansion'));
+    assert.ok(plan.every((item) => item.disposition === 'admission_rejected'));
+    fx.manager.close();
+  });
+
+  it('Bedrock cache counters use the same disjoint accounting contract', async () => {
+    const mock = flexibleMembrane([
+      { stop: 'refusal', inputTokens: 2, cacheCreationTokens: 210_000, cacheReadTokens: 130_000, provider: 'bedrock' },
+    ]);
+    const fx = await fixture(mock.membrane, {
+      compressionContextBudgetTokens: 350_000,
+      compressionRefusalCurveFallbacks: 1,
+    });
+    await fx.strategy.run(fx.target, managerContext(fx.manager));
+    assert.equal(mock.calls.length, 1);
+    const record = quarantineEvents(fx.manager).find((event) => event.kind === 'exhausted')!
+      .record as Record<string, unknown>;
+    assert.equal(record.canonicalProviderInputTokens, 340_002);
+    fx.manager.close();
+  });
+
+  it('prefers detailed provider usage over the top-level basic usage mirror', async () => {
+    const mock = flexibleMembrane([
+      {
+        stop: 'refusal',
+        inputTokens: 100_000,
+        topLevelInputTokens: 1,
+        cacheCreationTokens: 120_000,
+        cacheReadTokens: 80_000,
+        provider: 'anthropic',
+      },
+    ]);
+    const fx = await fixture(mock.membrane, {
+      compressionContextBudgetTokens: 310_000,
+      compressionRefusalCurveFallbacks: 1,
+    });
+    await fx.strategy.run(fx.target, managerContext(fx.manager));
+    assert.equal(mock.calls.length, 1, 'detailed total plus output reserve blocks the fallback');
+    const record = quarantineEvents(fx.manager).find((event) => event.kind === 'exhausted')!
+      .record as Record<string, unknown>;
+    assert.equal(record.canonicalProviderInputTokens, 300_000);
+    fx.manager.close();
+  });
+
+  it('does not double-count provider cache fields that are subsets of total input', async () => {
+    const mock = flexibleMembrane([
+      { stop: 'refusal', inputTokens: 200_000, cacheReadTokens: 150_000, provider: 'openai-responses-api' },
+      { stop: 'end_turn', text: 'subset-accounted fallback succeeded', inputTokens: 220_000 },
+    ]);
+    const fx = await fixture(mock.membrane, {
+      compressionContextBudgetTokens: 350_000,
+      compressionRefusalCurveFallbacks: 1,
+    });
+    await fx.strategy.run(fx.target, managerContext(fx.manager));
+    assert.equal(mock.calls.length, 2, 'OpenAI cached input is not added twice');
+    assert.equal(fx.target.compressed, true);
+    fx.manager.close();
+  });
+
+  it('zero or partial non-Anthropic usage falls back to the complete request bound', async () => {
+    const mock = flexibleMembrane([
+      { stop: 'refusal', inputTokens: 0, cacheReadTokens: 5, provider: 'openai-responses-api' },
+    ]);
+    const fx = await fixture(mock.membrane, {
+      compressionContextBudgetTokens: 60_000,
+      compressionRefusalCurveFallbacks: 1,
+    });
+    fx.manager.setToolDefinitions([{
+      name: 'large_zero_usage_tool',
+      description: 'schema inventory '.repeat(20_000),
+      inputSchema: { type: 'object', properties: {} },
+    }]);
+    await fx.strategy.run(fx.target, managerContext(fx.manager));
+    assert.equal(mock.calls.length, 1, 'degenerate usage cannot bypass the deterministic floor');
+    const record = quarantineEvents(fx.manager).find((event) => event.kind === 'exhausted')!
+      .record as Record<string, unknown>;
+    assert.equal(record.canonicalProviderInputTokens, undefined);
+    assert.ok((record.plan as Array<Record<string, unknown>>).every(
+      (item) => item.accountingSource === 'complete_normalized_request_bound',
+    ));
     fx.manager.close();
   });
 
@@ -1151,6 +1303,61 @@ describe('compression refusal recall curves', () => {
     manager.close();
   });
 
+  it('a new accounting version is not blocked by the old per-chunk shape cap', async () => {
+    const path = freshPath();
+    const firstMock = scriptedMembrane(['refusal']);
+    const first = await fixture(firstMock.membrane, { compressionRefusalCurveFallbacks: 0 }, path);
+    const targetIds = first.target.messages.map((message) => message.id);
+    await first.strategy.run(first.target, managerContext(first.manager));
+    const exhausted = quarantineEvents(first.manager).find((event) => event.kind === 'exhausted')!;
+    const current = exhausted.record as Record<string, unknown>;
+    await first.strategy.clearCompressionRefusalQuarantine(String(current.key));
+    for (let i = 0; i < 3; i++) {
+      const legacyConfig = { ...(current.normalizedConfig as Record<string, unknown>) };
+      delete legacyConfig.accountingVersion;
+      const legacy: Record<string, unknown> = {
+        ...structuredClone(current),
+        key: `legacy-key-${i}`,
+        familyKey: `legacy-family-${i}`,
+        accountingSource: 'legacy-byte-wall',
+        normalizedConfig: legacyConfig,
+      };
+      if (i === 0) delete legacy.normalizedConfig;
+      first.manager.getStore().appendToStateJsonWithIdentity(
+        'default/autobio:compression-refusal-quarantine-events',
+        { kind: 'exhausted', key: legacy.key, record: legacy, created: Date.now() + i },
+        'eventId',
+        'sequence',
+      );
+    }
+    first.manager.close();
+
+    const retryMock = scriptedMembrane(['end_turn']);
+    const retried = new ProbeStrategy({
+      compressionModel: MODEL,
+      targetChunkTokens: 100,
+      recentWindowTokens: 0,
+      headWindowTokens: 0,
+      minChunkCharsForLLM: 0,
+      mergeThreshold: 99,
+      compressionRefusalCurveFallbacks: 0,
+    });
+    const manager = await ContextManager.open({ path, strategy: retried, membrane: retryMock.membrane });
+    const ctx = managerContext(manager);
+    const chunk: Chunk = {
+      index: 999,
+      startIndex: 10,
+      endIndex: 12,
+      messages: targetIds.map((id) => ctx.messageStore.get(id)!).filter(Boolean),
+      tokens: 100,
+      compressed: false,
+    };
+    await retried.run(chunk, ctx);
+    assert.equal(retryMock.calls.length, 1, 'v2 accounting earns one fresh canonical attempt');
+    assert.equal(chunk.compressed, true);
+    manager.close();
+  });
+
   it('restart with fallback limit 1→3 invalidates the exhausted plan key', async () => {
     const path = freshPath();
     const firstMock = scriptedMembrane(['refusal']);
@@ -1190,7 +1397,7 @@ describe('compression refusal recall curves', () => {
 
   it('restart with a changed admission budget invalidates the exact plan key', async () => {
     const path = freshPath();
-    const firstMock = scriptedMembrane(['refusal']);
+    const firstMock = flexibleMembrane([{ stop: 'refusal', inputTokens: 20_000 }]);
     const first = await fixture(firstMock.membrane, {
       compressionRefusalCurveFallbacks: 3,
       compressionContextBudgetTokens: 19_000,

--- a/test/zero-recall-compression.test.ts
+++ b/test/zero-recall-compression.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { NormalizedMessage } from '@animalabs/membrane';
+import { transformZeroRecallCompression } from '../src/surgery/zero-recall-compression.js';
+
+const text = (participant: string, value: string): NormalizedMessage => ({ participant, content: [{ type: 'text', text: value }] });
+
+test('zero-recall surgery removes whole pairs and preserves all other messages', () => {
+  const signedAnswer: NormalizedMessage = {
+    participant: 'mythos',
+    content: [{ type: 'thinking', thinking: '', signature: 'sig' }, { type: 'text', text: 'summary' }],
+  };
+  const source = text('user', 'source');
+  const instruction = text('Context Manager', 'Compress now.');
+  const input = [
+    text('user', 'head'),
+    text('Context Manager', '[CM] Recall memory L1-1.'),
+    signedAnswer,
+    text('Context Manager', '[CM] Recall memory L2-2.'),
+    text('mythos', 'another summary'),
+    source,
+    instruction,
+  ];
+  const result = transformZeroRecallCompression(input);
+  assert.deepEqual(result.removedRecallIds, ['L1-1', 'L2-2']);
+  assert.equal(result.originalMessageCount, 7);
+  assert.equal(result.sentMessageCount, 3);
+  assert.deepEqual(result.messages[0], input[0]);
+  assert.deepEqual(result.messages[1], source);
+  assert.deepEqual(result.messages[2], instruction);
+  assert.notEqual(result.originalSha256, result.transformedSha256);
+});
+
+test('zero-recall surgery refuses malformed or absent recall geometry', () => {
+  assert.throws(() => transformZeroRecallCompression([text('user', 'source'), text('Context Manager', 'Compress now.')]), /No recall pairs/);
+  assert.throws(() => transformZeroRecallCompression([text('Context Manager', '[CM] Recall memory L1-1.')]), /missing assistant answer/);
+});


### PR DESCRIPTION
Adds the independently reviewed provider-total compression accounting repair plus a default-off, one-shot zero-prior-recall surgery tool. The tool requires exact store/tool/source/quarantine hashes, a named surgery branch, one provider call, and external-only provenance; it never retries, promotes, or restarts. Evidence: build/typecheck clean; focused accounting+surgery suite 54/54; parent negatives discriminate accounting; copied Mythos rehearsal made one natural request (58,543 input / 3,533 output), created exactly L1-2616 on the child branch, parent/source unchanged. Rehearsal receipt SHA-256: 4e474c35f844c77de75b7f18ef6380f15fa5e1cf1f872632c041ce05be0c79a7.