### PR TITLE
feat(compression): prompt-cache breakpoints on compression/merge requests (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ Releases up to and including 0.6.2 predate this file; for their contents see
   recall pair — with a 1h cache TTL (#37). The mint lane previously sent its
   entire recall prefix (~60–93% of input) uncached on every call. Markers are
   suppressed when the recall ladder was budget-capped (front-eviction shifts
-  the prefix, making cache writes counterproductive). New options:
+  the prefix, making cache writes counterproductive), and stale block-level
+  `cache_control` riding replayed imported content is stripped so the seams
+  can never push a request past Anthropic's 4-breakpoint limit. New options:
   `compressionCacheMarkers` (default `true`) and `compressionCacheTtl`
   (default `'1h'`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Releases up to and including 0.6.2 predate this file; for their contents see
 
 ## Unreleased
 
+### Added
+
+- Compression and merge requests now carry prompt-cache breakpoints at their
+  stability strata — end of head window, last level≥2 recall pair, last
+  recall pair — with a 1h cache TTL (#37). The mint lane previously sent its
+  entire recall prefix (~60–93% of input) uncached on every call. Markers are
+  suppressed when the recall ladder was budget-capped (front-eviction shifts
+  the prefix, making cache writes counterproductive). New options:
+  `compressionCacheMarkers` (default `true`) and `compressionCacheTtl`
+  (default `'1h'`).
+
 ### Fixed
 
 - Compression-refusal fallback admission now uses provider-aware total input

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -2203,7 +2203,27 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     recallLadder: readonly SummaryEntry[],
     capped: boolean,
   ): void {
-    if (this.config.compressionCacheMarkers === false || capped) return;
+    if (this.config.compressionCacheMarkers === false) return;
+    // Replayed history can carry stale BLOCK-level cache_control from the
+    // original live requests (imported stores; see membrane's native-formatter
+    // passthrough note). Those were another request's placement decisions, and
+    // the formatter counts them toward Anthropic's 4-breakpoint limit — left
+    // in place, two of them plus the three seams below would push the request
+    // past it and the API hard-rejects, stalling compression. Strip them
+    // (copy-on-write: block objects are shared with the message store).
+    // cache_control is request plumbing, not content, so verbatim-replay
+    // KV-honesty is unaffected. The kill switch above restores byte-exact
+    // pre-seam behavior, passthrough included.
+    for (const m of messages) {
+      if (m.content.some((b) => (b as { cache_control?: unknown }).cache_control !== undefined)) {
+        m.content = m.content.map((b) => {
+          if ((b as { cache_control?: unknown }).cache_control === undefined) return b;
+          const { cache_control: _stale, ...rest } = b as ContentBlock & { cache_control?: unknown };
+          return rest as ContentBlock;
+        });
+      }
+    }
+    if (capped) return;
     const levelById = new Map(recallLadder.map((s) => [s.id, s.level]));
     let headEnd = -1;
     let deepEnd = -1;

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -1062,6 +1062,9 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       this.config.compressionSlackRatio ??= 0.1;
       this.config.speculativeProduction ??= true;
     }
+    // Compression-lane prompt caching (issue #37)
+    this.config.compressionCacheMarkers ??= true;
+    this.config.compressionCacheTtl ??= '1h';
     // The solver committed to at construction. buildPicker compares the live
     // config against this on every compile: a runtime mutation (e.g. an
     // override merge carrying `foldingStrategy: undefined`) silently swaps
@@ -2166,6 +2169,62 @@ export class AutobiographicalStrategy implements ResettableStrategy {
     }
     kept.reverse();
     return { kept, keptTokens: total };
+  }
+
+  /**
+   * Issue #37: tag a mint request's stability strata with cache breakpoints.
+   *
+   * Consecutive compression/merge requests share a long, append-mostly
+   * prefix — head window + prior recall pairs (~60% of input on synthetic
+   * workloads, ~93% on mature stores) — that previously went to the API
+   * with zero `cache_control` and was re-read cold on every call. Markers
+   * land at the three boundaries whose survival probability ranks highest
+   * (measured optimum; `analysis/2026-08-20-cm37-cache-partition-experiments.md`
+   * in the workspace root):
+   *
+   *   1. end of head window        — survives everything short of identity edits
+   *   2. last level>=2 recall pair — survives appends AND L1→L2 merges (a
+   *      merge replaces the run at this boundary and extends it)
+   *   3. last recall pair          — the append frontier
+   *
+   * Only pairs whose id is in `recallLadder` (the kept prior-summary list)
+   * count as prefix: a merge's expanded SOURCE pairs are its volatile
+   * payload, and marking them would cache-write content that never recurs.
+   *
+   * `capped` requests get no markers: recall-budget front-eviction shifts
+   * the prefix on every subsequent mint, and cache writes on a shifting
+   * prefix are pure waste (measured up to +42% total cost at 1h TTL).
+   * Effective ladder reuse also requires the append-stable source order
+   * fix (2026-08-19); on stores minted under the older lexical order the
+   * markers are merely harmless.
+   */
+  protected applyMintCacheSeams(
+    messages: NormalizedRequest['messages'],
+    recallLadder: readonly SummaryEntry[],
+    capped: boolean,
+  ): void {
+    if (this.config.compressionCacheMarkers === false || capped) return;
+    const levelById = new Map(recallLadder.map((s) => [s.id, s.level]));
+    let headEnd = -1;
+    let deepEnd = -1;
+    let frontierEnd = -1;
+    for (let i = 0; i < messages.length - 1; i++) {
+      const m = messages[i]!;
+      if (m.participant !== 'Context Manager' || m.content.length !== 1) continue;
+      const block = m.content[0];
+      if (block?.type !== 'text') continue;
+      const match = /^\[CM\] Recall memory (.+)\.$/.exec(block.text);
+      if (!match) continue;
+      const level = levelById.get(match[1]!);
+      if (level === undefined) continue;
+      if (frontierEnd === -1 && i > 0) headEnd = i - 1;
+      frontierEnd = i + 1;
+      if (level >= 2) deepEnd = i + 1;
+    }
+    if (frontierEnd === -1) return; // no ladder yet — nothing stable to cache
+    for (const idx of new Set([headEnd, deepEnd, frontierEnd])) {
+      if (idx >= 0) messages[idx]!.cacheBreakpoint = true;
+    }
   }
 
   private sameAuthoredSummary(a: SummaryEntry, b: SummaryEntry): boolean {
@@ -5021,6 +5080,18 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         AutobiographicalStrategy.DEFAULT_MAX_COMPRESSION_IMAGE_BYTES,
     );
 
+    // Final wire-shape messages. Sanitize: strip empty text blocks and drop
+    // any message left with no content (empty text reaches the API as a 400
+    // that stalls ALL compression — see the twin note on the request below).
+    const mintMessages = cleaned
+      .map(m => ({ participant: m.participant, content: stripEmptyTextBlocks(m.content) }))
+      .filter(m => m.content.length > 0);
+    this.applyMintCacheSeams(
+      mintMessages,
+      keptSummaries,
+      keptSummaries.length < priorSummaries.length,
+    );
+
     const request: NormalizedRequest = {
       // EXPLICIT image-loss opt-in (2026-07-12): summarizer prompts replay
       // raw history that can carry more inline image bytes than the API's
@@ -5029,19 +5100,14 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       // preserve pixels — and membrane error-logs every exercised shed. All
       // other callers fail loudly instead (no silent transport mutation).
       shedOversizeImages: true,
-      // Sanitize: strip empty text blocks (`{type:'text',text:''}`) and drop any
-      // message left with no content. An empty-content turn (e.g. a silent/skip
-      // turn that produced no text) otherwise reaches the API as an empty text
-      // block → 400 "text content blocks must be non-empty", which throws in the
-      // speculative drain and stalls ALL compression. (Twin of the empty-summary
-      // recall-header guard — together they cover every source of the 400.)
       // NOTE (2026-07-16): thinking is stripped from RAW messages at their
-      // llmMessages insertion sites, not here — a blanket strip would also
-      // remove the recall-pair reasoning carriers, which must reach the API
-      // verbatim (see the recall-pair sites).
-      messages: cleaned
-        .map(m => ({ participant: m.participant, content: stripEmptyTextBlocks(m.content) }))
-        .filter(m => m.content.length > 0),
+      // llmMessages insertion sites, not in the mintMessages sanitize — a
+      // blanket strip would also remove the recall-pair reasoning carriers,
+      // which must reach the API verbatim (see the recall-pair sites).
+      messages: mintMessages,
+      // 1h TTL on the seam markers: steady-state mint cadence exceeds the
+      // 5-minute cache window, where markers cost more than they save.
+      cacheTtl: this.config.compressionCacheTtl,
       config: {
         model: this.requireCompressionModel(),
         // Generous output ceiling so a memory-write is never truncated mid-thought:
@@ -6343,6 +6409,20 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         AutobiographicalStrategy.DEFAULT_MAX_COMPRESSION_IMAGE_BYTES,
     );
 
+    // Final wire-shape messages. Sanitize: strip empty text blocks and drop
+    // any message left with no content (empty text reaches the API as a 400
+    // that stalls ALL compression — see the twin note on the request below).
+    // Seams count only `keptPriorSummaries` pairs as stable prefix — the
+    // expanded SOURCE pairs below the prior ladder are this merge's payload.
+    const mintMessages = cleaned
+      .map(m => ({ participant: m.participant, content: stripEmptyTextBlocks(m.content) }))
+      .filter(m => m.content.length > 0);
+    this.applyMintCacheSeams(
+      mintMessages,
+      keptPriorSummaries,
+      keptPriorSummaries.length < priorSummariesAll.length,
+    );
+
     // NO system prompt — identity is established by the head window
     // (present at the start of llmMessages above) and by the prior
     // recall pairs. Same rationale as compressChunkHierarchical.
@@ -6354,19 +6434,14 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       // preserve pixels — and membrane error-logs every exercised shed. All
       // other callers fail loudly instead (no silent transport mutation).
       shedOversizeImages: true,
-      // Sanitize: strip empty text blocks (`{type:'text',text:''}`) and drop any
-      // message left with no content. An empty-content turn (e.g. a silent/skip
-      // turn that produced no text) otherwise reaches the API as an empty text
-      // block → 400 "text content blocks must be non-empty", which throws in the
-      // speculative drain and stalls ALL compression. (Twin of the empty-summary
-      // recall-header guard — together they cover every source of the 400.)
       // NOTE (2026-07-16): thinking is stripped from RAW messages at their
-      // llmMessages insertion sites, not here — a blanket strip would also
-      // remove the recall-pair reasoning carriers, which must reach the API
-      // verbatim (see the recall-pair sites).
-      messages: cleaned
-        .map(m => ({ participant: m.participant, content: stripEmptyTextBlocks(m.content) }))
-        .filter(m => m.content.length > 0),
+      // llmMessages insertion sites, not in the mintMessages sanitize — a
+      // blanket strip would also remove the recall-pair reasoning carriers,
+      // which must reach the API verbatim (see the recall-pair sites).
+      messages: mintMessages,
+      // 1h TTL on the seam markers: steady-state mint cadence exceeds the
+      // 5-minute cache window, where markers cost more than they save.
+      cacheTtl: this.config.compressionCacheTtl,
       config: {
         model: this.requireCompressionModel(),
         // Generous output ceiling so a memory-write is never truncated mid-thought:

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -680,6 +680,34 @@ export interface AutobiographicalConfig {
   compressionRecallBudgetTokens?: number;
 
   /**
+   * Prompt-cache breakpoints on compression/merge requests (issue #37).
+   *
+   * Mint requests are dominated by a stable, append-mostly prefix (head
+   * window + prior recall pairs — ~60% synthetic, ~93% on mature stores)
+   * that was re-sent uncached on every call. When enabled, the request is
+   * tagged at its stability strata: end of head, last level>=2 recall pair,
+   * last recall pair. Markers are suppressed for any request whose recall
+   * ladder was budget-capped (`compressionRecallBudgetTokens`): front
+   * eviction shifts the prefix every mint, and measured cache writes there
+   * are pure waste (up to +42% cost). Requires append-stable ladder order
+   * (the 2026-08-19 source-order fix) to be effective.
+   *
+   * Default: true.
+   */
+  compressionCacheMarkers?: boolean;
+
+  /**
+   * Cache TTL for compression-lane breakpoints. Mint cadence is typically
+   * minutes-to-hours in steady state — beyond the 5-minute TTL, where
+   * markers cost more than they save — so the lane defaults to '1h'
+   * (write premium 2x vs 1.25x, break-even reuse probability 0.53 vs 0.22).
+   * Back-to-back drains work under either.
+   *
+   * Default: '1h'.
+   */
+  compressionCacheTtl?: '5m' | '1h';
+
+  /**
    * Maximum number of same-model recall-curve variants attempted after an L1
    * canonical request is explicitly refused. Each variant expands exactly one
    * already-authored frontier summary into its persisted direct children.

--- a/test/compression-cache-seams.test.ts
+++ b/test/compression-cache-seams.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Issue #37 regression: compression/merge requests carry cache breakpoints
+ * at their stability strata (end of head, last level>=2 recall pair, last
+ * recall pair), a 1h cache TTL, and NO markers when the recall ladder was
+ * budget-capped (front-eviction shifts the prefix, making cache writes pure
+ * waste) or when the kill switch is off.
+ *
+ * The mint request previously went to the API as bare {participant, content}
+ * messages — the inline builders structurally stripped every cache field —
+ * so every mint re-read its whole recall prefix cold (field data: 42/42 and
+ * 47/47 mints/day fully uncached).
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock, NormalizedRequest } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-compression-cache-seams';
+const TEST_COMPRESSION_MODEL = 'test-compression-model';
+
+function cleanup() {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+const t = (text: string): ContentBlock => ({ type: 'text', text });
+
+const RECALL_RE = /^\[CM\] Recall memory (.+)\.$/;
+const MARKER_SNIPPET = 'You will soon form a new memory';
+
+interface CapturedCall { request: NormalizedRequest }
+
+function createCapturingMembrane() {
+  const calls: CapturedCall[] = [];
+  const membrane = {
+    complete: async (request: NormalizedRequest) => {
+      calls.push({ request });
+      const summary =
+        'A stretch of routine traffic worth remembering in some detail: ' +
+        'word '.repeat(40);
+      return {
+        stopReason: 'end_turn',
+        content: [{ type: 'text', text: summary }],
+        usage: { input_tokens: 1000, output_tokens: 50 },
+      };
+    },
+  };
+  return { membrane, calls };
+}
+
+async function drain(manager: ContextManager): Promise<void> {
+  for (let i = 0; i < 500; i++) {
+    if (manager.isReady()) return;
+    await manager.tick();
+  }
+  throw new Error('drain: queue did not converge within 500 ticks');
+}
+
+/** Indices of recall-pair headers (single-text CM messages) in a request. */
+function recallHeaderIndices(request: NormalizedRequest): number[] {
+  const out: number[] = [];
+  request.messages.forEach((m, i) => {
+    const b = m.content[0];
+    if (
+      m.participant === 'Context Manager' &&
+      m.content.length === 1 &&
+      b?.type === 'text' &&
+      RECALL_RE.test(b.text)
+    ) out.push(i);
+  });
+  return out;
+}
+
+function breakpointIndices(request: NormalizedRequest): number[] {
+  const out: number[] = [];
+  request.messages.forEach((m, i) => { if (m.cacheBreakpoint) out.push(i); });
+  return out;
+}
+
+function isMerge(request: NormalizedRequest): boolean {
+  return !request.messages.some((m) =>
+    m.content.some((b) => b.type === 'text' && b.text.includes(MARKER_SNIPPET)));
+}
+
+async function runWorkload(
+  options: Record<string, unknown>,
+  turns: number,
+): Promise<CapturedCall[]> {
+  cleanup();
+  const { membrane, calls } = createCapturingMembrane();
+  const strategy = new AutobiographicalStrategy({
+    compressionModel: TEST_COMPRESSION_MODEL,
+    targetChunkTokens: 80,
+    headWindowTokens: 0,
+    recentWindowTokens: 0,
+    hierarchical: true,
+    ...options,
+  } as ConstructorParameters<typeof AutobiographicalStrategy>[0]);
+  const manager = await ContextManager.open({
+    path: TEST_STORE_PATH,
+    strategy,
+    membrane: membrane as any,
+  });
+  for (let i = 0; i < turns; i++) {
+    manager.addMessage(i % 2 === 0 ? 'user' : 'agent', [
+      t(`turn ${i} of steady substantive traffic about the ongoing work `.repeat(3)),
+    ]);
+    await drain(manager);
+  }
+  await manager.close();
+  return calls;
+}
+
+describe('Compression requests: cache seams (issue #37)', () => {
+  before(() => cleanup());
+  after(() => cleanup());
+
+  it('mints with a recall ladder mark the frontier pair and set the 1h TTL', async () => {
+    const calls = await runWorkload({}, 40);
+    const laddered = calls.filter((c) => recallHeaderIndices(c.request).length > 0 && !isMerge(c.request));
+    assert.ok(laddered.length >= 2, `expected laddered compress calls, got ${laddered.length}`);
+    for (const { request } of laddered) {
+      const headers = recallHeaderIndices(request);
+      const bps = breakpointIndices(request);
+      const frontierAnswer = headers[headers.length - 1] + 1;
+      assert.ok(bps.includes(frontierAnswer),
+        `frontier answer (idx ${frontierAnswer}) not marked; bps=[${bps}] headers=[${headers}]`);
+      assert.ok(bps.length <= 3, `at most 3 seams expected, got ${bps.length}`);
+      // Every marker must sit inside the ladder region (never on the marker,
+      // chunk slice, or instruction that follow the last pair).
+      for (const bp of bps) {
+        assert.ok(bp <= frontierAnswer, `marker at ${bp} lies past the frontier (${frontierAnswer})`);
+      }
+      assert.strictEqual(request.cacheTtl, '1h');
+    }
+  });
+
+  it('the first mint (no prior ladder) carries no markers', async () => {
+    const calls = await runWorkload({}, 40);
+    const first = calls[0].request;
+    assert.strictEqual(recallHeaderIndices(first).length, 0, 'first mint should have no recall pairs');
+    assert.strictEqual(breakpointIndices(first).length, 0, 'no ladder → nothing to mark');
+  });
+
+  it('merge requests mark only prior-ladder pairs, never expanded sources', async () => {
+    const calls = await runWorkload({ mergeThreshold: 2 }, 60);
+    const merges = calls.filter((c) => isMerge(c.request));
+    assert.ok(merges.length >= 2, `expected >=2 merges, got ${merges.length}`);
+    // The first merge consumes the oldest L1s — its prior ladder is empty
+    // (and, being an L2 merge, its sources expand to RAW messages, not
+    // pairs) — so it must carry no markers at all.
+    const firstMerge = merges[0].request;
+    assert.strictEqual(breakpointIndices(firstMerge).length, 0,
+      'empty prior ladder → no markers');
+    // Later merges with consolidated priors mark the prior frontier: every
+    // marker must sit on some recall-pair answer.
+    const marked = merges.filter((m) => breakpointIndices(m.request).length > 0);
+    assert.ok(marked.length >= 1, 'expected at least one merge with a prior ladder to be marked');
+    for (const { request } of marked) {
+      const answers = new Set(recallHeaderIndices(request).map((h) => h + 1));
+      for (const bp of breakpointIndices(request)) {
+        assert.ok(answers.has(bp), `marker at ${bp} is not a recall-pair answer`);
+      }
+    }
+    // L3+ merges expand their SOURCES as recall pairs too — those trail the
+    // prior ladder (pair answer directly before the closing instruction).
+    // Markers must never reach that source expansion.
+    const l3Merges = merges.filter((m) => {
+      const n = m.request.messages.length;
+      const headers = recallHeaderIndices(m.request);
+      return headers.length >= 2 && headers[headers.length - 1] === n - 3;
+    });
+    for (const { request } of l3Merges) {
+      const headers = recallHeaderIndices(request);
+      // mergeThreshold 2 → exactly two trailing source pairs.
+      const firstSourceHeader = headers[headers.length - 2];
+      for (const bp of breakpointIndices(request)) {
+        assert.ok(bp < firstSourceHeader,
+          `marker at ${bp} reaches the source expansion (starts at ${firstSourceHeader})`);
+      }
+    }
+  });
+
+  it('a budget-capped recall ladder suppresses all markers', async () => {
+    const calls = await runWorkload({ compressionRecallBudgetTokens: 150 }, 60);
+    const capped = calls.filter((c) => {
+      const headers = recallHeaderIndices(c.request);
+      return headers.length > 0 && !isMerge(c.request);
+    });
+    // With a 150-token ladder budget, later mints are necessarily capped
+    // (each summary is ~100 chars + 50 overhead); every capped request must
+    // carry zero markers.
+    const late = calls.slice(-3).filter((c) => !isMerge(c.request));
+    assert.ok(late.length > 0, 'expected late compress calls');
+    for (const { request } of late) {
+      assert.strictEqual(breakpointIndices(request).length, 0,
+        'capped ladder → markers suppressed (front-eviction shifts the prefix)');
+    }
+    assert.ok(capped.length > 0, 'expected at least one laddered call in the capped run');
+  });
+
+  it('compressionCacheMarkers: false disables seams entirely', async () => {
+    const calls = await runWorkload({ compressionCacheMarkers: false }, 40);
+    for (const { request } of calls) {
+      assert.strictEqual(breakpointIndices(request).length, 0);
+    }
+  });
+
+  it('head window present → the message before the first pair is marked', async () => {
+    const calls = await runWorkload({ headWindowTokens: 60 }, 40);
+    const laddered = calls.filter((c) => recallHeaderIndices(c.request).length > 0 && !isMerge(c.request));
+    assert.ok(laddered.length >= 1, 'expected laddered compress calls');
+    const { request } = laddered[laddered.length - 1];
+    const headers = recallHeaderIndices(request);
+    const bps = breakpointIndices(request);
+    if (headers[0] > 0) {
+      assert.ok(bps.includes(headers[0] - 1),
+        `head end (idx ${headers[0] - 1}) not marked; bps=[${bps}]`);
+    }
+  });
+});

--- a/test/compression-cache-seams.test.ts
+++ b/test/compression-cache-seams.test.ts
@@ -209,6 +209,47 @@ describe('Compression requests: cache seams (issue #37)', () => {
     }
   });
 
+  it('stale block-level cache_control on replayed content is stripped (4-breakpoint safety)', async () => {
+    cleanup();
+    const { membrane, calls } = createCapturingMembrane();
+    const strategy = new AutobiographicalStrategy({
+      compressionModel: TEST_COMPRESSION_MODEL,
+      targetChunkTokens: 80,
+      headWindowTokens: 0,
+      recentWindowTokens: 0,
+      hierarchical: true,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+      membrane: membrane as any,
+    });
+    for (let i = 0; i < 40; i++) {
+      // Imported histories can carry request-time cache_control on stored
+      // blocks (Arc exports). The formatter counts those toward Anthropic's
+      // 4-breakpoint limit alongside the seams.
+      const block = {
+        type: 'text',
+        text: `turn ${i} of imported traffic with stale markers `.repeat(3),
+        cache_control: { type: 'ephemeral' },
+      } as unknown as ContentBlock;
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent', [block]);
+      await drain(manager);
+    }
+    await manager.close();
+    assert.ok(calls.length > 0, 'expected compression calls');
+    for (const { request } of calls) {
+      for (const m of request.messages) {
+        for (const b of m.content) {
+          assert.strictEqual((b as { cache_control?: unknown }).cache_control, undefined,
+            'stale block-level cache_control must not reach the mint request');
+        }
+      }
+      assert.ok(breakpointIndices(request).length <= 3,
+        'total breakpoints must stay within the seam budget');
+    }
+  });
+
   it('head window present → the message before the first pair is marked', async () => {
     const calls = await runWorkload({ headWindowTokens: 60 }, 40);
     const laddered = calls.filter((c) => recallHeaderIndices(c.request).length > 0 && !isMerge(c.request));

--- a/test/fixtures/compression-canonical-request.json
+++ b/test/fixtures/compression-canonical-request.json
@@ -1,10 +1,11 @@
 {
   "shedOversizeImages": true,
+  "cacheTtl": "1h",
   "messages": [
     { "participant": "Context Manager", "content": [{ "type": "text", "text": "[CM] Recall memory L2-200." }] },
     { "participant": "Claude", "content": [{ "type": "text", "text": "authored L2-200" }] },
     { "participant": "Context Manager", "content": [{ "type": "text", "text": "[CM] Recall memory L2-201." }] },
-    { "participant": "Claude", "content": [{ "type": "text", "text": "authored L2-201" }] },
+    { "participant": "Claude", "content": [{ "type": "text", "text": "authored L2-201" }], "cacheBreakpoint": true },
     { "participant": "User", "content": [{ "text": "raw-8 substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive ", "type": "text" }] },
     { "participant": "Claude", "content": [{ "text": "raw-9 substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive ", "type": "text" }] },
     { "participant": "Context Manager", "content": [{ "type": "text", "text": "System: You will soon form a new memory, get ready. The messages that follow are the slice of recent experience you are about to compress. After them, write the memory in your own voice." }] },


### PR DESCRIPTION
Closes #37.

## What

Compression and merge requests now carry prompt-cache breakpoints at their three stability strata, with a 1h TTL:

1. **end of head window** — survives everything short of identity edits
2. **last level≥2 recall pair** — survives appends *and* L1→L2 merges (a merge replaces the run at exactly this boundary and extends it)
3. **last recall pair** — the append frontier

`applyMintCacheSeams` tags the final wire-shape messages in both inline builders (`compressChunkHierarchical`, `executeMerge`) — the `.map()` projections there were where any cache field previously got structurally discarded, and with no system prompt on the mint lane, membrane's fallback breakpoint had nowhere to land either. Only kept prior-ladder pairs count as prefix: a merge's expanded source pairs are its volatile payload and are never marked. Markers are suppressed for any request whose recall ladder was budget-capped (`compressionRecallBudgetTokens` front-eviction shifts the prefix on every subsequent mint, making cache writes strictly counterproductive — measured up to **+42%** total cost).

New options: `compressionCacheMarkers` (default `true`, kill switch) and `compressionCacheTtl` (default `'1h'`).

## Why these seams, this TTL

Consecutive mints share a long, append-mostly prefix — ~60% of input on synthetic workloads, ~93% on the mature stores in this issue's field data. Invalidation of that prefix is suffix-aligned (appends extend the frontier; merges replace the run at the consolidated-region boundary), so stability decreases monotonically along the request and a stratified marker ladder achieves the oracle bound. A breakpoint pays off iff its prefix's per-mint survival probability exceeds `(w−1)/(w−0.1)`: 0.217 at 5-minute TTL, 0.526 at 1h.

Policy sweep over recorded mint traces (7 workload regimes × 2 TTLs × 3 cadences, cache simulated with real Anthropic semantics — marked-prefix-only store, TTL with refresh-on-use, ≤4 slots, per-model minimum cacheable prefix — and scored against hindsight oracles):

- **Drains** (back-to-back mints): this ladder ≈ oracle, **32–46% mint-lane cost cut**.
- **Steady state** (~14-minute cadence): the 5-minute TTL makes *every* marker policy a net loss — hence the `'1h'` default (15–29% cut there).
- 4 marker slots provably suffice (unlimited-slot oracle = 4-slot oracle in every regime).
- Merge-heavy regimes (mergeThreshold 3) halve the benefit — frequent ladder rewrites; relevant to future demand-side merge work (#68).
- Budget-capped ladders: all policies net-negative (up to +42%) — hence the suppression.

## Verification

- `test/compression-cache-seams.test.ts` (6 tests): frontier/head/deep marking, 1h TTL, no markers on first mints, none on capped ladders, none on merge source expansions, kill switch.
- Full suite: 504/505 (the failing `snapshot-cadence-retune` subtest fails identically on clean `main`).
- Canonical-request fixture updated (gains `cacheTtl` + one `cacheBreakpoint`); the recall-curve variant tests pass against it unchanged in logic.
- **LLM-less A/B** (400-turn kv-stable workload, MockAdapter): mint lane 71×0bp → 68/71 at 1–2bp; live lane byte-identical with the patch stashed.
- **Live-fire A/B** (Haiku 4.5, real API): baseline (pre-patch, 2026-08-20) — 26/26 mints `cache_creation 0 / cache_read 0`. Patched — see numbers below.

  Patched (200-turn kv-stable workload, prod-like 6k head window, drain cadence): 40/43 mints carry 2–3 breakpoints; mint lane `cache_creation 29,857 / cache_read 114,535` — **23.3% cheaper than uncached** (240.6k billed token-equivalents vs 313.9k), 36.5% of mint input served from cache, at 1h-TTL write premiums. The per-mint sequence shows the designed incremental pattern: one mint writes its 4,436-token prefix, the next reads it and writes only a 374-token frontier delta.

## Caveats & interactions

- **Minimum cacheable prefix**: on Haiku 4.5 the floor is 4096 tokens (Sonnet-class: 1024) — small stores mint sub-floor prefixes that silently don't cache; markers there are harmless (no write occurs below the floor). Two live-fire runs at toy scale demonstrated exactly this before the geometry was scaled up.
- **Ordering prerequisite**: effective ladder reuse requires the append-stable source order from `08a3945` (currently unreleased — every released CM ≤ 0.6.3 still emits lexically-scrambled ladders, which is also what the field data's `nRecall` climb-and-reset pattern was). This PR and that fix ship together in the next release; on scrambled stores the markers are merely harmless.
- Retry-only recall-curve variants may drop a marker when they replace the marked pair — cosmetic (one uncached retry), not corrected here.

Companion bundle (theory + experiment write-up, both harnesses, full sweep result grids): https://gist.github.com/Anarchid/7070039bb95b2548935ffc7672c7b438

🤖 Generated with [Claude Code](https://claude.com/claude-code)
