### PR TITLE
feat(autobio): cache the compression and merge prompt prefix (head + recall-frontier breakpoints)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ Releases up to and including 0.6.2 predate this file; for their contents see
 
 ## Unreleased
 
+### Added
+
+- Compression (L1) and merge (L2+) requests now carry prompt-cache
+  breakpoints: one at the end of the head window, one at the end of
+  everything preceding the payload (the recall frontier and raw middle). These
+  requests previously carried no breakpoint at all, so the tools, head and
+  whole recall frontier were re-billed at full price on every summarizer call.
+  Marks reach the request as the message-level `cacheBreakpoint` flag, so
+  membrane applies them only when prompt caching is on and counts them against
+  its own budget; no content block changes shape, and no stored block is
+  mutated.
+- `compressionCacheTtl?: '5m' | '1h'` (default `'1h'`) sets `cacheTtl` on
+  those requests. 1h rather than the provider's 5m default because
+  steady-state compression cadence is longer than five minutes, so a 5m
+  breakpoint tends to bill the write premium and expire before the read.
+
 ### Fixed
 
 - Compression-refusal fallback admission now uses provider-aware total input

--- a/src/strategies/autobiographical.ts
+++ b/src/strategies/autobiographical.ts
@@ -731,6 +731,79 @@ function stripEmptyTextBlocks(content: ContentBlock[]): ContentBlock[] {
 }
 
 /**
+ * Sentinel marking a message as a prompt-cache breakpoint while a compression
+ * request is being assembled. Lifted to the message-level `cacheBreakpoint`
+ * flag by `liftCacheBreakpoints` when the request is built.
+ *
+ * It rides a CONTENT BLOCK rather than the message envelope because the
+ * envelope does not survive assembly: `splitMixedToolMessages`,
+ * `stripUnpairedToolBlocks` and the request-final `stripEmptyTextBlocks` map
+ * each return fresh `{participant, content}` objects, dropping every other
+ * field, and they split and merge messages so a positional index taken before
+ * the pipeline does not identify the same message after it. Blocks ride
+ * through by reference, so a block is the one thing that can carry a mark
+ * across.
+ *
+ * It is placed on a TEXT block: the API rejects `cache_control` on
+ * `thinking` / `redacted_thinking`, and recall-pair answers routinely end in
+ * signed reasoning carriers. Membrane enforces the same rule when it converts
+ * the lifted flag back into `cache_control` (`lastCacheableBlockIndex`).
+ *
+ * The marked block is CLONED. These arrays alias the store's own block
+ * objects, and a mark leaking back into the live compile would spend one of
+ * the provider's four breakpoints.
+ */
+const CACHE_BREAKPOINT_MARK = '__cmCacheBreakpoint';
+
+function markCacheBreakpoint(
+  msgs: Array<{ participant: string; content: ContentBlock[] }>,
+): void {
+  const last = msgs[msgs.length - 1];
+  if (!last) return;
+  for (let k = last.content.length - 1; k >= 0; k--) {
+    const block = last.content[k] as { type: string; text?: unknown };
+    if (block.type === 'text' && typeof block.text === 'string' && block.text.trim().length > 0) {
+      const content = last.content.slice();
+      content[k] = {
+        ...(last.content[k] as object),
+        [CACHE_BREAKPOINT_MARK]: true,
+      } as unknown as ContentBlock;
+      msgs[msgs.length - 1] = { participant: last.participant, content };
+      return;
+    }
+  }
+}
+
+/**
+ * Replace the assembly-time block sentinels with the message-level
+ * `cacheBreakpoint` flag membrane understands, leaving the blocks themselves
+ * exactly as they were.
+ *
+ * Going through `cacheBreakpoint` rather than writing `cache_control` onto the
+ * block directly is what makes these breakpoints behave like the live
+ * compile's. Membrane applies the flag only when prompt caching is on, so a
+ * host running a transport that rejects `cache_control` (`promptCaching:
+ * false` — Bedrock legacy Claude) keeps getting requests without it; a block
+ * written directly would be copied to the wire unconditionally and 400 there.
+ * It also counts toward membrane's breakpoint tally, so the redundant
+ * tools/system fallbacks are suppressed, and it places the marker via
+ * `lastCacheableBlockIndex` so it can never land on a thinking block.
+ */
+function liftCacheBreakpoints(
+  msg: { participant: string; content: ContentBlock[] },
+): { participant: string; content: ContentBlock[]; cacheBreakpoint?: boolean } {
+  const isMarked = (b: ContentBlock): boolean =>
+    !!(b as unknown as Record<string, unknown>)[CACHE_BREAKPOINT_MARK];
+  if (!msg.content.some(isMarked)) return msg;
+  const content = msg.content.map((b) => {
+    if (!isMarked(b)) return b;
+    const { [CACHE_BREAKPOINT_MARK]: _mark, ...rest } = b as unknown as Record<string, unknown>;
+    return rest as unknown as ContentBlock;
+  });
+  return { participant: msg.participant, content, cacheBreakpoint: true };
+}
+
+/**
  * Strip `thinking` / `redacted_thinking` blocks from RAW messages entering
  * compression input.
  *
@@ -4866,6 +4939,13 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       }
       llmMessages.push({ participant: m.participant, content: stripThinkingBlocks(m.content) });
     }
+    // Cache breakpoint 1 of 2 — end of the head window, so the cached prefix is
+    // tools + head. This is the request's permanent prefix: it survives every
+    // frontier change, so it still reads when breakpoint 2 has re-keyed.
+    // Nothing is pushed before the head loop, so a non-empty list here means
+    // the head produced messages; an entirely summary-covered head marks
+    // nothing and leaves breakpoint 2 to carry the request alone.
+    if (llmMessages.length > 0) markCacheBreakpoint(llmMessages);
     if (headCoveredSkipped > 0) {
       console.warn(
         `autobio: ${headCoveredSkipped} head-window message(s) are covered by live summaries; ` +
@@ -4948,6 +5028,17 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       participant: 'Context Manager',
       content: [{ type: 'text', text: COMPRESSION_MARKER }],
     });
+    // Cache breakpoint 2 of 2 — everything before the chunk: head + recall
+    // frontier + raw middle. Placed on the in-band marker rather than on the
+    // last recall-pair answer for two reasons. It is strictly more prefix
+    // (the raw middle joins the cached span), and it leaves every recall pair
+    // byte-identical to `summaryAnswerContent(parent)`, which
+    // `buildRecallCurveVariants` requires: it locates the pair to expand by
+    // exact JSON equality against that construction, so a `cache_control` on
+    // a pair body would silently cost that parent its refusal-fallback
+    // variant. The marker message always exists, so this needs no
+    // empty-frontier special case.
+    markCacheBreakpoint(llmMessages);
 
     // ---- 5. Chunk messages raw ----
     for (const m of chunk.messages) {
@@ -5041,7 +5132,12 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       // verbatim (see the recall-pair sites).
       messages: cleaned
         .map(m => ({ participant: m.participant, content: stripEmptyTextBlocks(m.content) }))
-        .filter(m => m.content.length > 0),
+        .filter(m => m.content.length > 0)
+        .map(liftCacheBreakpoints),
+      // TTL for the breakpoints marked during assembly. Membrane reads this
+      // when it converts them to `cache_control`, and ignores it when prompt
+      // caching is off.
+      cacheTtl: this.config.compressionCacheTtl ?? '1h',
       config: {
         model: this.requireCompressionModel(),
         // Generous output ceiling so a memory-write is never truncated mid-thought:
@@ -6072,6 +6168,9 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       }
       llmMessages.push({ participant: m.participant, content: stripThinkingBlocks(m.content) });
     }
+    // Cache breakpoint 1 of 2 — end of the head window (see the L1 site).
+    const headBreakpointAt = llmMessages.length;
+    if (llmMessages.length > 0) markCacheBreakpoint(llmMessages);
     if (headCoveredSkipped > 0) {
       console.warn(
         `autobio: ${headCoveredSkipped} head-window message(s) are covered by live summaries or ` +
@@ -6159,6 +6258,14 @@ export class AutobiographicalStrategy implements ResettableStrategy {
         llmMessages.push({ participant: m.participant, content: stripThinkingBlocks(m.content) });
       }
     }
+
+    // Cache breakpoint 2 of 2 — end of the prior recall frontier and raw
+    // middle, i.e. everything before the merge target. Marked only when this
+    // section produced messages; otherwise the head breakpoint is already the
+    // last one and re-marking it would be a no-op. Unlike the L1 site there is
+    // no in-band marker message to hang this on, and no exact-JSON matching to
+    // disturb: `buildRecallCurveVariants` runs on the L1 path only.
+    if (llmMessages.length > headBreakpointAt) markCacheBreakpoint(llmMessages);
 
     // ---- 2. TARGET: expand sources one level deeper ----
     // For L2 (sources at L1, sourceLevel=0): expand to raw L0 messages.
@@ -6366,7 +6473,12 @@ export class AutobiographicalStrategy implements ResettableStrategy {
       // verbatim (see the recall-pair sites).
       messages: cleaned
         .map(m => ({ participant: m.participant, content: stripEmptyTextBlocks(m.content) }))
-        .filter(m => m.content.length > 0),
+        .filter(m => m.content.length > 0)
+        .map(liftCacheBreakpoints),
+      // TTL for the breakpoints marked during assembly. Membrane reads this
+      // when it converts them to `cache_control`, and ignores it when prompt
+      // caching is off.
+      cacheTtl: this.config.compressionCacheTtl ?? '1h',
       config: {
         model: this.requireCompressionModel(),
         // Generous output ceiling so a memory-write is never truncated mid-thought:

--- a/src/types/strategy.ts
+++ b/src/types/strategy.ts
@@ -680,6 +680,20 @@ export interface AutobiographicalConfig {
   compressionRecallBudgetTokens?: number;
 
   /**
+   * `cacheTtl` for compression (L1) and merge (L2+) requests, which carry a
+   * prompt-cache breakpoint after the head window and another at the end of
+   * the recall frontier. Default '1h'. Ignored, like the breakpoints
+   * themselves, when prompt caching is off.
+   *
+   * Why 1h rather than the provider's 5m default: compression calls arrive
+   * every ~12-48 minutes in steady state, so a 5m breakpoint usually expires
+   * before the next call and bills the write premium with no read to show for
+   * it. Bursts (a backlog draining chunk after chunk) hit either TTL. Set
+   * '5m' if your deployment compresses in tight bursts and never in trickle.
+   */
+  compressionCacheTtl?: '5m' | '1h';
+
+  /**
    * Maximum number of same-model recall-curve variants attempted after an L1
    * canonical request is explicitly refused. Each variant expands exactly one
    * already-authored frontier summary into its persisted direct children.

--- a/test/compression-cache-breakpoints.test.ts
+++ b/test/compression-cache-breakpoints.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Prompt-cache breakpoints on compression (L1) and merge (L2+) requests.
+ *
+ * A summarizer prompt re-sends the tools, the head window and the whole recall
+ * frontier around a chunk that is a small fraction of the payload, and used to
+ * carry no breakpoint at all — the stable prefix was re-billed in full on
+ * every call.
+ *
+ * Load-bearing properties:
+ *  - a compression request marks the end of the head window and the in-band
+ *    compression marker, and nothing else;
+ *  - marks reach the request as the message-level `cacheBreakpoint` flag, not
+ *    as `cache_control` written onto a block: membrane applies the flag only
+ *    when prompt caching is on, so a transport that rejects `cache_control`
+ *    keeps working, and the flag is counted so the redundant tools/system
+ *    fallbacks are suppressed;
+ *  - the assembly-time block sentinel never survives into the request;
+ *  - no recall-pair answer is marked — `buildRecallCurveVariants` matches a
+ *    pair to expand by exact JSON equality against `summaryAnswerContent`,
+ *    so a marked pair body would silently lose that parent its fallback;
+ *  - the store's own content blocks are never mutated;
+ *  - merge requests are marked too;
+ *  - at most 2 strategy breakpoints per request, leaving room under the
+ *    provider's 4-block limit.
+ */
+
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert';
+import { rmSync, existsSync } from 'node:fs';
+import { ContextManager, AutobiographicalStrategy } from '../src/index.js';
+import type { ContentBlock } from '@animalabs/membrane';
+
+const TEST_STORE_PATH = './test-compression-cache-breakpoints';
+const TEST_COMPRESSION_MODEL = 'test-compression-model';
+const HEAD_SENTINEL = 'HEAD_SENTINEL_OPENING';
+const MARKER_PREFIX = 'System: You will soon form a new memory';
+
+function cleanup() {
+  if (existsSync(TEST_STORE_PATH)) {
+    rmSync(TEST_STORE_PATH, { recursive: true, force: true });
+  }
+}
+
+interface ApiMessage { participant: string; content: ContentBlock[]; cacheBreakpoint?: boolean }
+interface ApiRequest { messages: ApiMessage[]; cacheTtl?: string }
+
+function createCapturingMembrane() {
+  const calls: ApiRequest[] = [];
+  const membrane = {
+    complete: async (request: ApiRequest) => {
+      calls.push(request);
+      const inputChars = request.messages
+        .flatMap((m) => m.content)
+        .map((b) => (b as { text?: string }).text ?? '')
+        .join('').length;
+      const summary = `[mock summary] ` + 'x '.repeat(Math.max(30, Math.floor(inputChars / 10)));
+      return {
+        stopReason: 'end_turn',
+        content: [{ type: 'text', text: summary }],
+        usage: { input_tokens: Math.ceil(inputChars / 4), output_tokens: Math.ceil(summary.length / 4) },
+      };
+    },
+  };
+  return { membrane, calls };
+}
+
+const t = (s: string): ContentBlock => ({ type: 'text', text: s });
+
+function flatText(m: ApiMessage): string {
+  return m.content.map((b) => (b as { text?: string }).text ?? '').join(' ');
+}
+
+/** Indices of messages flagged as cache breakpoints. */
+function markedMessageIndexes(messages: ApiMessage[]): number[] {
+  return messages.map((m, i) => (m.cacheBreakpoint ? i : -1)).filter((i) => i >= 0);
+}
+
+/**
+ * Blocks carrying either the assembly-time sentinel or a hand-written
+ * `cache_control`. Both must be zero in a built request: the sentinel is
+ * internal, and writing `cache_control` directly would bypass membrane's
+ * prompt-caching gate.
+ */
+function strayMarkedBlocks(messages: ApiMessage[]): number {
+  return messages.reduce(
+    (n, m) =>
+      n +
+      m.content.filter((b) => {
+        const rec = b as unknown as Record<string, unknown>;
+        return !!rec['__cmCacheBreakpoint'] || !!rec['cache_control'];
+      }).length,
+    0,
+  );
+}
+
+async function drain(manager: ContextManager): Promise<void> {
+  for (let i = 0; i < 500; i++) {
+    if (manager.isReady()) return;
+    await manager.tick();
+  }
+  throw new Error('drain: queue did not converge within 500 ticks');
+}
+
+describe('Compression prompt-cache breakpoints', () => {
+  before(() => cleanup());
+  after(() => cleanup());
+
+  it('marks the head window and the in-band marker, and nothing else', async () => {
+    cleanup();
+    const { membrane, calls } = createCapturingMembrane();
+    const strategy = new AutobiographicalStrategy({
+      compressionModel: TEST_COMPRESSION_MODEL,
+      targetChunkTokens: 80,
+      headWindowTokens: 60, // covers the two sentinel opening messages
+      recentWindowTokens: 0,
+      hierarchical: true,
+      mergeThreshold: 100, // keep this test on pure L1 calls
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+      membrane: membrane as any,
+    });
+
+    manager.addMessage('user', [t(`${HEAD_SENTINEL} can you explore a story with me`)]);
+    manager.addMessage('agent', [t('HEAD_SENTINEL_REPLY yes let us explore that story together')]);
+
+    const filler = (i: number) => `event ${i} ` + 'substantive words about real happenings '.repeat(8);
+    for (let i = 0; i < 40; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent', [t(filler(i))]);
+    }
+
+    await drain(manager);
+    assert.ok(calls.length >= 2, `expected multiple L1 calls, got ${calls.length}`);
+
+    let withRecalls = 0;
+    for (const call of calls) {
+      const texts = call.messages.map(flatText);
+      const headIdx = texts.findIndex((s) => s.includes(HEAD_SENTINEL));
+      const markerIdx = texts.findIndex((s) => s.includes(MARKER_PREFIX));
+      assert.ok(headIdx >= 0, 'head window must be present in every compression request');
+      assert.ok(markerIdx >= 0, 'in-band compression marker must be present');
+
+      // The head breakpoint sits on the LAST head message, which is the one
+      // immediately before the first recall pair (or before the marker when
+      // the frontier is empty) — not necessarily the sentinel itself.
+      const marked = markedMessageIndexes(call.messages);
+      assert.equal(
+        marked.length,
+        2,
+        `expected exactly 2 marked messages, got ${marked.length} in [${marked.join(', ')}]`,
+      );
+      assert.equal(
+        strayMarkedBlocks(call.messages),
+        0,
+        'no block may carry the internal sentinel or a hand-written cache_control',
+      );
+      assert.ok(
+        marked[0]! >= headIdx && marked[0]! < markerIdx,
+        `head breakpoint (idx ${marked[0]}) must land in the head window, before the marker (idx ${markerIdx})`,
+      );
+      assert.equal(marked[1], markerIdx, 'second breakpoint must be the in-band marker');
+
+      const recallIdx = texts.findIndex((s) => s.includes('[CM] Recall memory'));
+      if (recallIdx >= 0) {
+        withRecalls++;
+        assert.ok(
+          marked[0]! < recallIdx,
+          'head breakpoint must precede the recall frontier so it survives frontier churn',
+        );
+      }
+
+      // Every marked message ends in a non-empty text block, so membrane's
+      // lastCacheableBlockIndex can never be forced onto a thinking block.
+      for (const i of marked) {
+        const content = call.messages[i]!.content;
+        const last = content[content.length - 1] as { type: string; text?: string };
+        assert.equal(last.type, 'text', 'a marked message must end in a text block');
+        assert.ok((last.text ?? '').trim().length > 0, 'that text block must be non-empty');
+      }
+      assert.equal(call.cacheTtl, '1h', 'default breakpoint TTL');
+    }
+    assert.ok(withRecalls >= 1, 'expected at least one call carrying recall pairs');
+
+    await manager.close();
+  });
+
+  it('leaves recall-pair answers unmarked (recall-curve variants match by exact JSON)', async () => {
+    cleanup();
+    const { membrane, calls } = createCapturingMembrane();
+    const strategy = new AutobiographicalStrategy({
+      compressionModel: TEST_COMPRESSION_MODEL,
+      targetChunkTokens: 80,
+      headWindowTokens: 60,
+      recentWindowTokens: 0,
+      hierarchical: true,
+      mergeThreshold: 100,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+      membrane: membrane as any,
+    });
+
+    manager.addMessage('user', [t(`${HEAD_SENTINEL} can you explore a story with me`)]);
+    manager.addMessage('agent', [t('HEAD_SENTINEL_REPLY yes let us explore that story together')]);
+    const filler = (i: number) => `event ${i} ` + 'substantive words about real happenings '.repeat(8);
+    for (let i = 0; i < 40; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent', [t(filler(i))]);
+    }
+    await drain(manager);
+
+    let pairsChecked = 0;
+    for (const call of calls) {
+      const texts = call.messages.map(flatText);
+      for (let i = 0; i < call.messages.length - 1; i++) {
+        if (!texts[i]!.includes('[CM] Recall memory')) continue;
+        pairsChecked++;
+        for (const idx of [i, i + 1]) {
+          assert.ok(
+            !call.messages[idx]!.cacheBreakpoint,
+            `recall pair message ${idx} must not be a breakpoint`,
+          );
+          assert.equal(
+            strayMarkedBlocks([call.messages[idx]!]),
+            0,
+            `recall pair message ${idx} must be byte-identical to its canonical construction ` +
+              '— any added field here costs that parent its refusal-curve variant',
+          );
+        }
+      }
+    }
+    assert.ok(pairsChecked >= 1, 'expected at least one recall pair to check');
+
+    await manager.close();
+  });
+
+  it('never mutates the stored content blocks', async () => {
+    cleanup();
+    const { membrane } = createCapturingMembrane();
+    const strategy = new AutobiographicalStrategy({
+      compressionModel: TEST_COMPRESSION_MODEL,
+      targetChunkTokens: 80,
+      headWindowTokens: 60,
+      recentWindowTokens: 0,
+      hierarchical: true,
+      mergeThreshold: 100,
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+      membrane: membrane as any,
+    });
+
+    manager.addMessage('user', [t(`${HEAD_SENTINEL} can you explore a story with me`)]);
+    manager.addMessage('agent', [t('HEAD_SENTINEL_REPLY yes let us explore that story together')]);
+    const filler = (i: number) => `event ${i} ` + 'substantive words about real happenings '.repeat(8);
+    for (let i = 0; i < 40; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent', [t(filler(i))]);
+    }
+    await drain(manager);
+
+    const stored = manager.getAllMessages();
+    assert.ok(stored.length > 0, 'fixture must have stored messages');
+    for (const m of stored) {
+      assert.equal(
+        strayMarkedBlocks([{ participant: m.participant, content: m.content }]),
+        0,
+        'a mark on a stored block would leak into the live compile and ' +
+          'spend one of the provider\'s four breakpoints',
+      );
+    }
+
+    await manager.close();
+  });
+
+  it('marks merge requests too', async () => {
+    cleanup();
+    const { membrane, calls } = createCapturingMembrane();
+    const strategy = new AutobiographicalStrategy({
+      compressionModel: TEST_COMPRESSION_MODEL,
+      targetChunkTokens: 80,
+      headWindowTokens: 60,
+      recentWindowTokens: 0,
+      hierarchical: true,
+      mergeThreshold: 3, // force L2 merges
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+      membrane: membrane as any,
+    });
+
+    manager.addMessage('user', [t(`${HEAD_SENTINEL} can you explore a story with me`)]);
+    manager.addMessage('agent', [t('HEAD_SENTINEL_REPLY yes let us explore that story together')]);
+    const filler = (i: number) => `event ${i} ` + 'substantive words about real happenings '.repeat(8);
+    for (let i = 0; i < 80; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent', [t(filler(i))]);
+    }
+    await drain(manager);
+
+    // Merge requests carry the merge instruction rather than the L1 marker.
+    const merges = calls.filter((c) => !c.messages.some((m) => flatText(m).includes(MARKER_PREFIX)));
+    assert.ok(merges.length >= 1, `expected at least one merge call, got ${merges.length}`);
+    for (const call of merges) {
+      const marked = markedMessageIndexes(call.messages);
+      assert.ok(marked.length >= 1, 'a merge request must carry at least the head breakpoint');
+      assert.ok(
+        marked.length <= 2,
+        `at most 2 strategy breakpoints (provider allows 4 incl. membrane fallbacks), got ${marked.length}`,
+      );
+      assert.equal(strayMarkedBlocks(call.messages), 0, 'no stray block-level marks');
+      for (const i of marked) {
+        const content = call.messages[i]!.content;
+        const last = content[content.length - 1] as { type: string };
+        assert.equal(last.type, 'text', 'a marked message must end in a text block');
+      }
+    }
+
+    await manager.close();
+  });
+
+  it('honors compressionCacheTtl', async () => {
+    cleanup();
+    const { membrane, calls } = createCapturingMembrane();
+    const strategy = new AutobiographicalStrategy({
+      compressionModel: TEST_COMPRESSION_MODEL,
+      targetChunkTokens: 80,
+      headWindowTokens: 60,
+      recentWindowTokens: 0,
+      hierarchical: true,
+      mergeThreshold: 100,
+      compressionCacheTtl: '5m',
+    });
+    const manager = await ContextManager.open({
+      path: TEST_STORE_PATH,
+      strategy,
+      membrane: membrane as any,
+    });
+
+    manager.addMessage('user', [t(`${HEAD_SENTINEL} can you explore a story with me`)]);
+    manager.addMessage('agent', [t('HEAD_SENTINEL_REPLY yes let us explore that story together')]);
+    const filler = (i: number) => `event ${i} ` + 'substantive words about real happenings '.repeat(8);
+    for (let i = 0; i < 24; i++) {
+      manager.addMessage(i % 2 === 0 ? 'user' : 'agent', [t(filler(i))]);
+    }
+    await drain(manager);
+
+    assert.ok(calls.length >= 1, 'expected at least one compression call');
+    for (const call of calls) {
+      assert.equal(call.cacheTtl, '5m', 'configured breakpoint TTL reaches the request');
+      assert.ok(
+        markedMessageIndexes(call.messages).length >= 1,
+        'expected at least one breakpoint alongside the configured ttl',
+      );
+    }
+
+    await manager.close();
+  });
+});

--- a/test/fixtures/compression-canonical-request.json
+++ b/test/fixtures/compression-canonical-request.json
@@ -1,5 +1,6 @@
 {
   "shedOversizeImages": true,
+  "cacheTtl": "1h",
   "messages": [
     { "participant": "Context Manager", "content": [{ "type": "text", "text": "[CM] Recall memory L2-200." }] },
     { "participant": "Claude", "content": [{ "type": "text", "text": "authored L2-200" }] },
@@ -7,7 +8,7 @@
     { "participant": "Claude", "content": [{ "type": "text", "text": "authored L2-201" }] },
     { "participant": "User", "content": [{ "text": "raw-8 substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive ", "type": "text" }] },
     { "participant": "Claude", "content": [{ "text": "raw-9 substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive ", "type": "text" }] },
-    { "participant": "Context Manager", "content": [{ "type": "text", "text": "System: You will soon form a new memory, get ready. The messages that follow are the slice of recent experience you are about to compress. After them, write the memory in your own voice." }] },
+    { "participant": "Context Manager", "content": [{ "type": "text", "text": "System: You will soon form a new memory, get ready. The messages that follow are the slice of recent experience you are about to compress. After them, write the memory in your own voice." }], "cacheBreakpoint": true },
     { "participant": "User", "content": [{ "text": "raw-10 substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive ", "type": "text" }] },
     { "participant": "Claude", "content": [{ "text": "raw-11 substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive substantive ", "type": "text" }] },
     { "participant": "Context Manager", "content": [{ "type": "text", "text": "Write the memory of events since the most recent memory system notification. Speak in the first person from your own perspective. Preserve concrete details — file paths, exact values, decisions, unresolved questions, the user's active asks. Target ~2000 tokens. Output only the memory body — no preamble, no section headers unless they help preservation, no meta-commentary about summarizing. Memorize only what actually happened in that slice: if it holds little beyond routine system traffic (heartbeats, empty turns, failure notices), a short memory saying so is correct — do not pad it by re-narrating events you already remember from earlier as if they had just happened again." }] }


### PR DESCRIPTION
## Problem

Compression (L1) and merge (L2+) requests carry no cache breakpoint at all. `cacheMarker` / `cacheBreakpoint` appear only on the live compile path (`placeCacheMarkers`); the two request builders — the `tools: ctx.tools` sites in `compressChunkHierarchical` and the merge builder — send none.

Every summarizer call re-sends the tools, the head window and the entire recall frontier around a chunk that is a small fraction of the payload. That prefix is byte-identical call to call and was re-billed in full every time. On a production Connectome agent (Fable 5) the observed shape was ~52K input per compression call, ~48K of it stable prefix, at tens to low hundreds of calls per day.

#65 makes this worth doing now: with the recall frontier ordered by message position it is append-only in steady state, so an end-of-frontier breakpoint actually reads on the next call instead of being invalidated by a mid-frontier insertion.

## Changes

Two breakpoints per request:

1. **End of the head window** — cached prefix is tools + head. This is the request's permanent prefix: it survives every frontier change, so it still reads when breakpoint 2 has re-keyed. Skipped when the head is entirely summary-covered and produced no messages.
2. **End of everything preceding the payload** — the recall frontier plus the raw middle. On the L1 path this lands on the in-band compression marker; on the merge path, on the last message before the target expansion.

**Marks reach the request as the message-level `cacheBreakpoint` flag**, the same mechanism the live compile uses — not as `cache_control` written onto a block. That distinction is load-bearing in three ways:

- Membrane applies the flag **only when prompt caching is on**. A host running a transport that rejects `cache_control` (`promptCaching: false` — Bedrock legacy Claude, per membrane's own `defaultPromptCaching` note) keeps getting requests without it. A `cache_control` written straight onto a block would be copied to the wire unconditionally by both membrane builders and 400 there. This is the one thing I'd most like a second pair of eyes on, since it's the difference between "opt-in caching" and "silently breaks a provider".
- It **counts** toward membrane's breakpoint tally, so the now-redundant tools/system fallbacks are suppressed — 2 breakpoints per request rather than 3.
- It is placed via `lastCacheableBlockIndex`, so it can never land on a `thinking` block (recall-pair answers routinely end in signed reasoning carriers, and the API rejects `cache_control` there).

Getting the flag onto the right message needs one indirection, which is the only slightly unusual part of the diff. The mark is carried through assembly on a **content block** and lifted to the envelope in the request-final map. The envelope cannot carry it: `splitMixedToolMessages`, `stripUnpairedToolBlocks` and the request-final `stripEmptyTextBlocks` map each rebuild `{participant, content}`, dropping every other field, and they split and merge messages, so an index taken before the pipeline doesn't identify the same message after it. Blocks ride through by reference, so a block is the only thing that can carry a mark across. The sentinel is stripped when it's lifted and the block is restored unchanged — a test asserts no sentinel and no hand-written `cache_control` ever reaches a built request.

**The L1 breakpoint sits on the in-band marker rather than on the last recall-pair answer.** That placement covers strictly more prefix (the raw middle joins the cached span), and — the load-bearing reason — it leaves every recall pair untouched. `buildRecallCurveVariants` locates the pair to expand by exact JSON equality against `summaryAnswerContent(parent)`, so any added field on a pair body would make the match fail and silently cost that parent its refusal-fallback variant. There's a regression test for this.

New `compressionCacheTtl?: '5m' | '1h'`, default `'1h'`, set as the request's `cacheTtl`. I picked 1h over the provider's 5m default because steady-state compression cadence is longer than five minutes, so a 5m breakpoint tends to bill the write premium and expire before the read; bursts hit either TTL. That's a judgment call from one deployment's cadence, not a measurement across deployments — happy to flip the default to `'5m'` if you'd rather the conservative one.

**Fixture change:** `test/fixtures/compression-canonical-request.json` gains the top-level `cacheTtl` and `cacheBreakpoint: true` on the in-band marker message. I diffed the regenerated request against the frozen one field by field before touching it: same keys otherwise, same config, same 10 messages, same participants, and **every content block byte-identical**. The two tests that read it (`canonical success stores once…`, `builds the expected variant…`) pass otherwise unchanged — the second is the one that would break if the placement disturbed pair matching.

## Tests

`npm test` on this branch: **495 pass / 0 fail.**
`npm test` on `main` (`ef989c6`, clean `dist/`): **490 pass / 0 fail.**
`npx tsc --noEmit`: clean.

The 5 new tests are in `test/compression-cache-breakpoints.test.ts`, driving the real path through `ContextManager.open` + a capturing membrane:

- head window and in-band marker are flagged, and nothing else (exactly 2, each ending in a non-empty text block, `cacheTtl` on the request);
- recall-pair headers and answers are never flagged and never gain a field (the variant-matching invariant);
- no stored content block is ever mutated;
- merge requests are flagged too, and never with more than 2;
- `compressionCacheTtl` reaches the request.

Checked they fail on unfixed code: with `src/strategies/autobiographical.ts` stashed and rebuilt, **3 of the 5 fail** (`marks the head window and the in-band marker`, `marks merge requests too`, `honors compressionCacheTtl`). The other two are absence-invariants that hold vacuously on the unmarked baseline; they exist to pin behavior against a future placement change, not to fail today.

## Not verified

- **I have not compiled this branch against a real store, and I have not captured wire-level `cache_read` / `cache_write` counters from this code.** The ~48K-prefix figure above, and a "45K cache_read / 2K cache_write / 5–10K uncached" result, come from an earlier breakpoint patch on a 0.6.0 deployment that wrote `cache_control` onto the last recall-pair answer directly. This branch places the second breakpoint later (more prefix) and routes through `cacheBreakpoint`, so I expect it to be no worse — but that is inference about a different implementation, not a measurement of this one.
- The breakpoint-budget reasoning (2 marked, fallbacks suppressed, under the limit of 4) comes from reading membrane's two builders, not from a captured request.
- No deployment evidence for the merge path at all; it's covered by the suite only.
- Not exercised: Bedrock or any transport that rejects `cache_control`. The design is specifically meant to keep working there, but I have only argued it from membrane's source, not run it.
- Not measured: whether the head breakpoint earns its slot on stores where the head window is small. It is cheap, but I have no data separating its contribution from breakpoint 2's.

## Out of scope

- Membrane copies block-level `cache_control` to the wire regardless of `promptCaching`. That asymmetry with the message-level path is what this PR routes around rather than relies on; if you'd rather it were fixed there, that's a membrane change and I'm happy to file it.

---

- [x] `CHANGELOG.md` updated under `## Unreleased`

*Posted by Claude Code (Opus 5)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GL15NBP1KtrEAxyE3pay4z
