### PR TITLE
feat: export OverBudgetError and UncoveredDropError from the package root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ Releases up to and including 0.6.2 predate this file; for their contents see
 
 ## Unreleased
 
+### Added
+
+- **`OverBudgetError`, `UncoveredDropError` (and `OverBudgetDiagnostics`) are
+  exported from the package root** (#41). Both errors are cross-package
+  behavioral surface — agent-framework gates its OverBudget drain breaker and
+  `context_refusal` classification on them (AF PR #58,
+  `classifyInferenceError`) but could only match `err.name` across the
+  boundary. Consumers now get a real `instanceof`; the constructors' message
+  wording stops being implicitly load-bearing. Additive, no behavior change.
+
 ### Fixed
 
 - Compression-refusal fallback admission now uses provider-aware total input

--- a/src/adaptive/index.ts
+++ b/src/adaptive/index.ts
@@ -87,6 +87,7 @@ export {
   OverBudgetError,
   UncoveredDropError,
   accountFrontier,
+  type OverBudgetDiagnostics,
   type PickerInputs,
   type PickerResult,
   type PickerChunk,

--- a/src/adaptive/picker.ts
+++ b/src/adaptive/picker.ts
@@ -28,6 +28,15 @@ import type {
 import type { SummaryEntry } from '../types/strategy.js';
 import { getSummaryParentId } from '../types/strategy.js';
 
+/** Diagnostic snapshot of the picker's final state when it refused. */
+export interface OverBudgetDiagnostics {
+  headTokens: number;
+  tailTokens: number;
+  middleTokens: number;
+  middleChunkCount: number;
+  deepestLevel: number;
+}
+
 /**
  * Error raised when the picker has folded everything it can and the
  * resulting context still exceeds the hard token budget.
@@ -37,6 +46,10 @@ import { getSummaryParentId } from '../types/strategy.js';
  * larger-context model, drop the head/tail windows explicitly, or surface a
  * "context too large" error to the user.
  *
+ * Cross-package behavioral surface: agent-framework gates its OverBudget
+ * drain breaker on this error (AF PR #58), so it is re-exported from the
+ * package root for a real `instanceof` across the boundary.
+ *
  * See `docs/adaptive-resolution-design.md` §3.10.
  */
 export class OverBudgetError extends Error {
@@ -45,13 +58,7 @@ export class OverBudgetError extends Error {
   /** The token count the strategy could not reduce below `budget`. */
   readonly actual: number;
   /** Diagnostic snapshot of the picker's final state. */
-  readonly diagnostics: {
-    headTokens: number;
-    tailTokens: number;
-    middleTokens: number;
-    middleChunkCount: number;
-    deepestLevel: number;
-  };
+  readonly diagnostics: OverBudgetDiagnostics;
 
   constructor(opts: {
     budget: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,13 @@ export { KnowledgeStrategy } from './strategies/knowledge.js';
 // Utilities
 export { splitMixedToolMessages, stripUnpairedToolBlocks } from './normalize-tool-messages.js';
 
+// Errors — cross-package behavioral surface. agent-framework gates its
+// OverBudget drain breaker on these errors (AF PR #58, framework.ts
+// classifyInferenceError); exporting them from the root gives consumers a
+// real `instanceof` instead of stringly-typed `err.name` matching.
+export { OverBudgetError, UncoveredDropError } from './adaptive/picker.js';
+export type { OverBudgetDiagnostics } from './adaptive/picker.js';
+
 // Types
 export type {
   // Message types

--- a/test/overbudget-export.test.ts
+++ b/test/overbudget-export.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Issue #41: OverBudgetError is cross-package behavioral surface.
+ *
+ * agent-framework gates its OverBudget drain breaker (AF PR #58) on this
+ * error, but with the class buried in `adaptive/picker.ts` it could not
+ * `instanceof` it across the package boundary and fell back to matching
+ * `err.name === 'OverBudgetError'` — stringly-typed coupling that made the
+ * constructor's message wording implicitly load-bearing.
+ *
+ * These tests pin the root export: the class is reachable from the package
+ * root, it is the SAME class object the picker throws (so `instanceof`
+ * works), and the diagnostics fields consumers read are present.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { OverBudgetError, UncoveredDropError } from '../src/index.js';
+import type { OverBudgetDiagnostics } from '../src/index.js';
+import {
+  OverBudgetError as PickerOverBudgetError,
+  UncoveredDropError as PickerUncoveredDropError,
+} from '../src/adaptive/picker.js';
+
+const diagnostics: OverBudgetDiagnostics = {
+  headTokens: 1000,
+  tailTokens: 2000,
+  middleTokens: 5000,
+  middleChunkCount: 7,
+  deepestLevel: 3,
+};
+
+describe('OverBudgetError root export (issue #41)', () => {
+  it('is the same class object as the one the picker throws', () => {
+    // Identity, not just shape — if these ever diverge, a consumer's
+    // root-import `instanceof` silently stops matching picker throws.
+    assert.strictEqual(OverBudgetError, PickerOverBudgetError);
+  });
+
+  it('instanceof works on an error constructed by the picker module', () => {
+    const err: unknown = new PickerOverBudgetError({ budget: 4000, actual: 8000, diagnostics });
+    assert.ok(err instanceof OverBudgetError);
+    assert.ok(err instanceof Error);
+  });
+
+  it('carries the diagnostics shape consumers read', () => {
+    const err = new OverBudgetError({ budget: 4000, actual: 8000, diagnostics });
+    assert.strictEqual(err.budget, 4000);
+    assert.strictEqual(err.actual, 8000);
+    assert.deepStrictEqual(err.diagnostics, diagnostics);
+  });
+
+  it('keeps name (the pre-export detection contract AF currently relies on)', () => {
+    const err = new OverBudgetError({ budget: 4000, actual: 8000, diagnostics });
+    assert.strictEqual(err.name, 'OverBudgetError');
+  });
+});
+
+describe('UncoveredDropError root export (issue #41)', () => {
+  // AF gates its context_refusal classification on this error by name too
+  // (framework.ts classifyInferenceError) — same boundary, same fix.
+  it('is the same class object as the one the picker throws', () => {
+    assert.strictEqual(UncoveredDropError, PickerUncoveredDropError);
+  });
+
+  it('instanceof works and name is kept', () => {
+    const err: unknown = new PickerUncoveredDropError({
+      droppedIds: ['chunk-1', 'chunk-2'],
+      site: 'selectHierarchical',
+      diagnostics: { budget: 4000, totalTokens: 8000 },
+    });
+    assert.ok(err instanceof UncoveredDropError);
+    assert.strictEqual((err as Error).name, 'UncoveredDropError');
+  });
+});


### PR DESCRIPTION
## Problem

`OverBudgetError` is cross-package behavioral surface: agent-framework gates its OverBudget drain breaker on it (AF PR #58), but with the class defined in `adaptive/picker.ts` and not exported from the package root, AF cannot `instanceof` it across the package boundary and instead matches `err.name === 'OverBudgetError'` (with a message-prose fallback) — stringly-typed coupling that makes the constructor's message wording implicitly load-bearing.

Fixes #41.

## Changes

- Re-export `OverBudgetError` from the package root (`src/index.ts`).
- Also re-export `UncoveredDropError`: AF's `classifyInferenceError` gates its `context_refusal` classification on that error by `err.name` too (`framework.ts`, right next to the OverBudget match) — same boundary, same fix. Flagging it since it's one class beyond the issue's literal ask; happy to drop it if you'd rather keep this strictly scoped.
- Name the diagnostics shape as `export interface OverBudgetDiagnostics` (previously an anonymous inline type) and export it as a type from the root and from `adaptive/index.ts`, so consumers can type against head/tail/middle/budget fields.
- Changelog entry under `## Unreleased → ### Added`, same commit.

Additive, no behavior change — no call sites modified, `adaptive/index.ts` exports unchanged in behavior.

## Tests

- New `test/overbudget-export.test.ts` pins the export: root class is the **same object** as the picker's (`strictEqual` identity, so a future refactor can't silently split them), `instanceof` works on picker-constructed errors, `name` is kept (the pre-export detection contract AF relies on today), and the diagnostics fields are present.
- `npm test` on ubuntu (Node 24): **496 pass / 0 fail** (baseline on `main`: 490 / 0; the +6 are this PR's).
- `npx tsc --noEmit`: clean.

## Not verified

- Agent-framework was not switched to `instanceof` here — that's a follow-up companion PR on the AF side (`classifyInferenceError`). Safe to land this side first; AF's `err.name` matching keeps working unchanged.

## Companion PRs

None yet. Enables a future AF change replacing `err.name === 'OverBudgetError'` / `'UncoveredDropError'` with real `instanceof` checks; this PR is safe to merge alone and first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)